### PR TITLE
Restrict landing mask to hero section

### DIFF
--- a/src/app/components/hero/hero.component.scss
+++ b/src/app/components/hero/hero.component.scss
@@ -1,3 +1,8 @@
+:host {
+  position: relative;
+  display: block;
+}
+
 .bg-container {
   padding: 0;
   display: flex;

--- a/src/app/components/landing-mask/landing-mask.component.scss
+++ b/src/app/components/landing-mask/landing-mask.component.scss
@@ -1,9 +1,9 @@
 :host {
-    position: fixed;
+    position: absolute;
     top: 0;
     left: 0;
-    width: 100vw;
-    height: 100vh;
+    width: 100%;
+    height: 100%;
     pointer-events: none;
     z-index: 1;
 }


### PR DESCRIPTION
## Summary
- keep mask overlay within hero instead of entire page
- set hero component root relative

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846afc9162c832b887e00135cc2f242