### PR TITLE
Fix stats hours calculation

### DIFF
--- a/src/app/components/stats/stats.component.ts
+++ b/src/app/components/stats/stats.component.ts
@@ -80,7 +80,7 @@ export class StatsComponent implements OnInit {
       let hoursWorked = weeks * hoursWorkedPerWeek;
 
       if (index === experiencesWithTechnologies.length - 1) {
-        hoursWorked += weeks;
+        hoursWorked += hoursWorkedPerWeek; // add one week of hours
       }
 
       totalHours += hoursWorked;


### PR DESCRIPTION
## Summary
- ensure final week hours use consistent units in stats component

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846b0786ba8832b8d4c6422ab01e0d2