### PR TITLE
Fix custom popup test property name

### DIFF
--- a/src/app/components/custom-popup/custom-popup.component.spec.ts
+++ b/src/app/components/custom-popup/custom-popup.component.spec.ts
@@ -26,15 +26,17 @@ describe('CustomPopupComponent', () => {
     expect(compiled.querySelector('p')?.textContent).toContain('Test Popup Message');
   });
 
-  it('should have the popup visible when isVisible is true', () => {
-    component.isVisible = true;
+  // should show the popup when the isPopupVisible property is true
+  it('should have the popup visible when isPopupVisible is true', () => {
+    component.isPopupVisible = true;
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
     expect(compiled.querySelector('.popup')?.classList).not.toContain('popup-hidden');
   });
 
-  it('should have the popup hidden when isVisible is false', () => {
-    component.isVisible = false;
+  // should hide the popup when the isPopupVisible property is false
+  it('should have the popup hidden when isPopupVisible is false', () => {
+    component.isPopupVisible = false;
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
     expect(compiled.querySelector('.popup')?.classList).toContain('popup-hidden');


### PR DESCRIPTION
## Summary
- update test references to `isPopupVisible`
- clarify comments to use `isPopupVisible`

## Testing
- `npm test --silent -- --watch=false` *(fails: ng not found)*
- `npm install` *(fails: network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6846b07818b8832ba6e46a2a5e353cf7