### PR TITLE
Update landing mask scattering

### DIFF
--- a/src/app/components/landing-mask/landing-mask.component.ts
+++ b/src/app/components/landing-mask/landing-mask.component.ts
@@ -89,7 +89,8 @@ export class LandingMaskComponent implements AfterViewInit, OnDestroy {
     const panelCount = window.innerWidth < 768 ? 10 : 20;
     const centerX = 0;
     const centerY = 0;
-    const margin = 80;
+    // distance from the edges where panels will stop
+    const margin = 20;
 
     const screenW = window.innerWidth;
     const screenH = window.innerHeight;
@@ -119,8 +120,9 @@ export class LandingMaskComponent implements AfterViewInit, OnDestroy {
 
       return {
         class: `panel-${i}`,
-        posX: centerX,
-        posY: centerY,
+        // start slightly around the center so the panels appear already spread
+        posX: centerX + (Math.random() - 0.5) * 200,
+        posY: centerY + (Math.random() - 0.5) * 200,
         posZ: 0,
         rotX: Math.random() * 40 - 20,
         rotY: Math.random() * 40 - 20,


### PR DESCRIPTION
## Summary
- adjust margin so panels stop nearer to screen edges
- randomize initial panel positions around the center

## Testing
- `npm test` *(fails: ng not found)*
- `npm run build` *(fails: ng not found)*


------
https://chatgpt.com/codex/tasks/task_e_6846c0714430832b9f9abc84c43a1207