### PR TITLE
Add blue and green themes

### DIFF
--- a/src/app/components/navigator/navigator.component.html
+++ b/src/app/components/navigator/navigator.component.html
@@ -21,6 +21,12 @@
       <button class="option-button" (click)="changeTheme('dark')" aria-label="Dark mode">
         <mat-icon>dark_mode</mat-icon>
       </button>
+      <button class="option-button" (click)="changeTheme('blue')" aria-label="Blue mode">
+        <mat-icon>water_drop</mat-icon>
+      </button>
+      <button class="option-button" (click)="changeTheme('green')" aria-label="Green mode">
+        <mat-icon>eco</mat-icon>
+      </button>
     </div>
   </div>
 

--- a/src/app/components/navigator/navigator.component.ts
+++ b/src/app/components/navigator/navigator.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatIconModule } from '@angular/material/icon';
 import { TranslationService } from '../../services/translation.service';
@@ -13,7 +13,7 @@ import { TranslationService } from '../../services/translation.service';
   templateUrl: './navigator.component.html',
   styleUrls: ['./navigator.component.scss']
 })
-export class NavigatorComponent {
+export class NavigatorComponent implements OnInit {
   @Input() totalSections: number = 8;
   @Input() currentSectionIndex: number = 0;
   @Output() navigateNext = new EventEmitter<void>();
@@ -23,10 +23,16 @@ export class NavigatorComponent {
   showThemeOptions = false;
 
   currentLang: string;
-  currentTheme: string = 'light';
+  currentTheme: 'light' | 'dark' | 'blue' | 'green' = 'light';
 
   constructor(private translationService: TranslationService) {
     this.currentLang = this.translationService.getCurrentLanguage();
+  }
+
+  ngOnInit(): void {
+    const storedTheme = (localStorage.getItem('theme') as 'light' | 'dark' | 'blue' | 'green') || 'light';
+    this.currentTheme = storedTheme;
+    this.applyTheme(storedTheme);
   }
 
   onNext(): void {
@@ -57,13 +63,21 @@ export class NavigatorComponent {
     this.showLanguageOptions = false;
   }
 
-  changeTheme(theme: string): void {
+  changeTheme(theme: 'light' | 'dark' | 'blue' | 'green'): void {
     this.currentTheme = theme;
-    document.body.classList.toggle('dark-mode', theme === 'dark');
-
+    localStorage.setItem('theme', theme);
+    this.applyTheme(theme);
     this.showThemeOptions = false;
+  }
 
-    // Future: handle more themes (e.g., 'solarized', 'blue-hue', etc.)
-    // You could emit an event or use a ThemeService here.
+  private applyTheme(theme: 'light' | 'dark' | 'blue' | 'green'): void {
+    document.body.classList.remove('dark-mode', 'blue-mode', 'green-mode');
+    if (theme === 'dark') {
+      document.body.classList.add('dark-mode');
+    } else if (theme === 'blue') {
+      document.body.classList.add('blue-mode');
+    } else if (theme === 'green') {
+      document.body.classList.add('green-mode');
+    }
   }
 }

--- a/src/styles/blue.scss
+++ b/src/styles/blue.scss
@@ -1,0 +1,22 @@
+@use 'variables' as *;
+
+body.blue-mode {
+  background-color: #e0f2ff;
+  color: #102a43;
+
+  .bg-container {
+    background: linear-gradient(135deg, #60a5fa, #3b82f6, #2563eb);
+  }
+
+  .project-card,
+  .skill-section,
+  .statistics-card,
+  .popup {
+    background-color: #ffffff;
+    box-shadow: $section-box-shadow;
+  }
+
+  .point-on-line {
+    background-color: #2563eb;
+  }
+}

--- a/src/styles/green.scss
+++ b/src/styles/green.scss
@@ -1,0 +1,22 @@
+@use 'variables' as *;
+
+body.green-mode {
+  background-color: #e6fff2;
+  color: #1f4033;
+
+  .bg-container {
+    background: linear-gradient(135deg, #6ee7b7, #34d399, #10b981);
+  }
+
+  .project-card,
+  .skill-section,
+  .statistics-card,
+  .popup {
+    background-color: #ffffff;
+    box-shadow: $section-box-shadow;
+  }
+
+  .point-on-line {
+    background-color: #10b981;
+  }
+}

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -1,6 +1,8 @@
 @use 'variables' as *;
 @use 'light';
 @use 'dark';
+@use 'blue';
+@use 'green';
 @use 'responsiveness/mobile';
 @use 'responsiveness/tablet';
 @use 'responsiveness/pc';


### PR DESCRIPTION
## Summary
- expand theme palette with blue and green modes
- persist chosen theme in localStorage
- load the saved theme on startup
- show palette icons for the two new themes

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846c8780c4c832b93c1e4e88c827f3d