### PR TITLE
Implement theme icon and selection highlight

### DIFF
--- a/src/app/components/navigator/navigator.component.html
+++ b/src/app/components/navigator/navigator.component.html
@@ -17,19 +17,23 @@
   <div class="nav-group">
     <button class="nav-button" (click)="toggleThemeOptions()" aria-label="Theme selector"
       [matTooltip]="currentLang === 'en' ? 'Theme' : 'Tema'" matTooltipPosition="left">
-      <mat-icon>palette</mat-icon>
+      <mat-icon>{{ getThemeIcon(currentTheme) }}</mat-icon>
     </button>
     <div class="option-container" *ngIf="showThemeOptions">
-      <button class="option-button" (click)="changeTheme('light')" aria-label="Light mode">
+      <button class="option-button" (click)="changeTheme('light')" aria-label="Light mode"
+        [class.selected]="currentTheme === 'light'">
         <mat-icon>light_mode</mat-icon>
       </button>
-      <button class="option-button" (click)="changeTheme('dark')" aria-label="Dark mode">
+      <button class="option-button" (click)="changeTheme('dark')" aria-label="Dark mode"
+        [class.selected]="currentTheme === 'dark'">
         <mat-icon>dark_mode</mat-icon>
       </button>
-      <button class="option-button" (click)="changeTheme('blue')" aria-label="Blue mode">
+      <button class="option-button" (click)="changeTheme('blue')" aria-label="Blue mode"
+        [class.selected]="currentTheme === 'blue'">
         <mat-icon>water_drop</mat-icon>
       </button>
-      <button class="option-button" (click)="changeTheme('green')" aria-label="Green mode">
+      <button class="option-button" (click)="changeTheme('green')" aria-label="Green mode"
+        [class.selected]="currentTheme === 'green'">
         <mat-icon>eco</mat-icon>
       </button>
     </div>

--- a/src/app/components/navigator/navigator.component.scss
+++ b/src/app/components/navigator/navigator.component.scss
@@ -168,6 +168,10 @@ body.dark-mode {
         font-weight: 600;
         color: #333;
     }
+
+    &.selected {
+        background-color: rgba(0, 0, 0, 0.1);
+    }
 }
 
 body.dark-mode {
@@ -179,5 +183,9 @@ body.dark-mode {
     .option-button .section-number {
         position: absolute;
         color: #f0f0f0;
+    }
+
+    .option-button.selected {
+        background-color: rgba(255, 255, 255, 0.2);
     }
 }

--- a/src/app/components/navigator/navigator.component.ts
+++ b/src/app/components/navigator/navigator.component.ts
@@ -98,4 +98,20 @@ export class NavigatorComponent implements OnInit {
       }
     }
   }
+
+  /**
+   * Returns the Material icon name corresponding to the given theme.
+   */
+  getThemeIcon(theme: 'light' | 'dark' | 'blue' | 'green'): string {
+    switch (theme) {
+      case 'dark':
+        return 'dark_mode';
+      case 'blue':
+        return 'water_drop';
+      case 'green':
+        return 'eco';
+      default:
+        return 'light_mode';
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- show the icon of the currently selected theme in the navigator
- highlight the active theme option

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68470ef6aa04832ba390e0c4613c36f8