### PR TITLE
Fix navigator hints, theme handling, and add toggle button

### DIFF
--- a/src/app/components/navigator/navigator.component.html
+++ b/src/app/components/navigator/navigator.component.html
@@ -1,22 +1,27 @@
+<!-- Floating toggle button -->
+<button class="nav-toggle-button" *ngIf="!isOpen" (click)="toggleNavigator()" aria-label="Open navigator">
+  <mat-icon>chevron_left</mat-icon>
+</button>
+
 <!-- Modern, animated, circular floating navbar -->
-<div class="modern-navigator">
+<div class="modern-navigator" *ngIf="isOpen">
   <div class="arrow-container">
     <!-- Previous button -->
     <button class="arrow-button" (click)="onPrevious()" aria-label="Previous section"
-      [matTooltip]="currentLang === 'en' ? 'Previous section' : 'Sezione precedente'" matTooltipPosition="left">
+      [matTooltip]="getTooltip('prev')" matTooltipPosition="left">
       <mat-icon>arrow_upward</mat-icon>
     </button>
 
     <!-- Next button -->
     <button class="arrow-button" (click)="onNext()" aria-label="Next section"
-      [matTooltip]="currentLang === 'en' ? 'Next section' : 'Sezione successiva'" matTooltipPosition="left">
+      [matTooltip]="getTooltip('next')" matTooltipPosition="left">
       <mat-icon>arrow_downward</mat-icon>
     </button>
   </div>
 
   <div class="nav-group">
     <button class="nav-button" (click)="toggleThemeOptions()" aria-label="Theme selector"
-      [matTooltip]="currentLang === 'en' ? 'Theme' : 'Tema'" matTooltipPosition="left">
+      [matTooltip]="getTooltip('theme')" matTooltipPosition="left">
       <mat-icon>{{ getThemeIcon(currentTheme) }}</mat-icon>
     </button>
     <div class="option-container" *ngIf="showThemeOptions">
@@ -40,7 +45,7 @@
   </div>
 
   <div class="nav-group">
-    <button class="nav-button" (click)="toggleLanguageOptions()" [matTooltip]="currentLang === 'en' ? 'Language' : 'Lingua'"
+    <button class="nav-button" (click)="toggleLanguageOptions()" [matTooltip]="getTooltip('language')"
       matTooltipPosition="left">
       <span class="lang-label">{{ currentLang | slice:0:3 | uppercase }}</span>
     </button>

--- a/src/app/components/navigator/navigator.component.scss
+++ b/src/app/components/navigator/navigator.component.scss
@@ -6,6 +6,37 @@ $navigator-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
 $navigator-icon-size: 24px;
 $navigator-button-size: 48px;
 
+@keyframes float {
+    0%, 100% { transform: translateY(0); }
+    50% { transform: translateY(-4px); }
+}
+
+.nav-toggle-button {
+    position: fixed;
+    bottom: 30px;
+    right: 30px;
+    width: $navigator-button-size;
+    height: $navigator-button-size;
+    border-radius: 50%;
+    background-color: $navigator-bg;
+    box-shadow: $navigator-shadow;
+    border: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    animation: float 3s ease-in-out infinite;
+    cursor: pointer;
+    z-index: 9999;
+
+    mat-icon {
+        font-size: $navigator-icon-size;
+        color: #333;
+    }
+
+    &:hover {
+        background-color: lighten($navigator-bg, 4%);
+    }
+}
 
 .modern-navigator {
     position: fixed;
@@ -85,6 +116,17 @@ $navigator-button-size: 48px;
 }
 
 body.dark-mode {
+    .nav-toggle-button {
+        background-color: $navigator-bg-dark;
+
+        mat-icon {
+            color: #f0f0f0;
+        }
+
+        &:hover {
+            background-color: lighten($navigator-bg-dark, 5%);
+        }
+    }
     .modern-navigator {
 
         .nav-button,
@@ -101,6 +143,48 @@ body.dark-mode {
         .nav-button .lang-label,
         .arrow-button mat-icon {
             color: #f0f0f0;
+        }
+    }
+}
+
+body.blue-mode {
+    .nav-toggle-button {
+        background-color: $navigator-bg;
+
+        &:hover {
+            background-color: lighten($navigator-bg, 4%);
+        }
+    }
+    .modern-navigator {
+        .nav-button,
+        .arrow-container {
+            background-color: $navigator-bg;
+        }
+
+        .nav-button:hover,
+        .arrow-button:hover {
+            background-color: lighten($navigator-bg, 4%);
+        }
+    }
+}
+
+body.green-mode {
+    .nav-toggle-button {
+        background-color: $navigator-bg;
+
+        &:hover {
+            background-color: lighten($navigator-bg, 4%);
+        }
+    }
+    .modern-navigator {
+        .nav-button,
+        .arrow-container {
+            background-color: $navigator-bg;
+        }
+
+        .nav-button:hover,
+        .arrow-button:hover {
+            background-color: lighten($navigator-bg, 4%);
         }
     }
 }

--- a/src/app/components/navigator/navigator.component.spec.ts
+++ b/src/app/components/navigator/navigator.component.spec.ts
@@ -22,6 +22,7 @@ describe('NavigatorComponent', () => {
 
     fixture = TestBed.createComponent(NavigatorComponent);
     component = fixture.componentInstance;
+    component.isOpen = true;
     fixture.detectChanges();
   });
 


### PR DESCRIPTION
## Summary
- ensure NavigatorComponent updates language by subscribing to TranslationService
- add theme-aware floating toggle button for Navigator
- translate all navigator tooltips
- update styles for theme variants
- adjust unit tests for new navigator visibility logic

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847110378bc832bb585d80533293714