### PR TITLE
Add portfolio improvement plan documentation

### DIFF
--- a/docs/portfolio-improvement-plan.md
+++ b/docs/portfolio-improvement-plan.md
@@ -1,0 +1,77 @@
+# Portfolio Improvement Plan
+
+## 1. Current Architecture Overview
+- **Single-page layout with section navigation.** The home page renders hero, about, projects, skills, education, experiences, stats, and contact components in sequence, with keyboard navigation handled in `HomeComponent`.【F:src/app/pages/home/home.component.ts†L1-L82】【F:src/app/pages/home/home.component.html†L1-L14】
+- **Content sourced from localized data objects.** Hero copy, project listings, skills, and other text are stored in `src/app/data` files and provided to the UI through the `TranslationService`, which currently supports English, Italian, German, and Spanish locales.【F:src/app/data/hero.data.ts†L1-L42】【F:src/app/data/projects.data.ts†L1-L101】【F:src/app/services/translation.service.ts†L1-L23】
+- **Standalone Angular components.** Each section is implemented as an Angular standalone component, using shared styles and data-driven templates (e.g., `ProjectsComponent` for carousel behavior).【F:src/app/components/projects/projects.component.ts†L1-L75】
+
+## 2. Key Observations
+- **Hero lacks value proposition detail.** The hero text cycles generic statements without describing your hybrid offering (web development, video editing, drone services). The CTA button also lacks context.
+- **Services aren’t grouped or differentiated.** Sections such as About, Skills, and Projects mention abilities, but there’s no explicit services overview or packaged offers (e.g., website bundles, drone shoots, social media kits).
+- **Projects showcase only software repositories.** There’s no space for multimedia case studies (video edits, drone footage) or simulated client work.
+- **No roadmap or “coming soon” messaging.** Drone ambitions are not surfaced, missing an opportunity to set expectations and capture leads.
+- **Assets strategy unclear.** Large media files aren’t yet integrated; we must plan for size constraints before adding drone videos.
+
+## 3. Proposed Enhancements
+### 3.1 Content & UX
+1. **Rework the hero section** to emphasize the multi-disciplinary offering. Add a subtitle like “Sviluppatore web junior & video creator con droni”, adjust the rotating text to highlight each service, and change the CTA to “Prenota una call gratuita”.
+2. **Add a Services/Packages section** immediately after the hero or before projects. Break offerings into cards:
+   - `Sviluppo Web` (landing page express, siti dinamici, web app su misura)
+   - `Produzione Video & Drone` (riprese aeree, montaggio, color grading)
+   - `Digital Support` (gestione social, automazioni, consulenze)
+   - Include “Coming Soon” tags for drone packages if certification is pending.
+3. **Introduce a “Processo di lavoro” timeline** showing steps from brief to delivery, reassuring leads about structure.
+4. **Expand the Portfolio section** into tabs or filters (Software, Video, Drone, Social). For each drone/video item, include a thumbnail, project goals, tools, and an embedded player or external link.
+5. **Highlight testimonials and training roadmap.** Add a section summarizing certifications in progress (esame A1/A3, pratica drone) and quotes from collaborators.
+6. **Enhance the contact section** with a booking widget (Calendly embed or custom calendar) and explicit lead magnet (es. checklist per video promozionale).
+
+### 3.2 Technical Improvements
+1. **Refactor data models** to group services and media entries in dedicated TypeScript DTOs (e.g., `ServiceDTO`, `MediaProjectDTO`). This keeps translations consistent and simplifies adding new categories.
+2. **Implement lazy loading for heavy sections**, especially if drone/video galleries become asset-heavy. Use Angular’s standalone route-level lazy loading or intersection observers to defer initialization.
+3. **Optimize the project carousel** to support video thumbnails, modals, or external streaming links without blocking rendering. Consider using Angular signals for state to simplify subscriptions.
+4. **Add structured data (JSON-LD)** for services and person schema to improve SEO.
+5. **Internationalize new copy.** Ensure translation files cover Italian and English at minimum; optionally simplify to two priority languages to reduce maintenance.
+6. **Accessibility & performance**: add alt text for images, ensure keyboard navigation for carousels, and audit Lighthouse metrics once media is integrated.
+
+## 4. Drone & Video Integration Strategy
+- **Showcase placement**
+  - Create a dedicated `DroneShowcaseComponent` with a hero reel, service description, and FAQs about regolamentazione.
+  - Feature a highlighted case study (anche simulato) with storyboard, obiettivi, risultati, e clip breve.
+- **Media handling**
+  - Store raw files externally (YouTube unlisted, Vimeo, or cloud storage with signed URLs) and embed via responsive `<iframe>` to avoid bundling large binaries.
+  - For on-site previews, generate 10–15 second teaser clips compressed to <4 MB using H.264 MP4 (720p) and place them in `src/assets/videos`. Use Angular’s `ngOptimizedImage` or a custom lazy loader for video tags.
+  - Provide downloadable deliverables via cloud links (Google Drive/Dropbox) rather than repository assets to keep deploy bundle small.
+  - Consider using GIF-like MP4 loops or WebM for silent background loops in the hero, compressed with `ffmpeg -crf 28 -preset veryslow`.
+- **Content ideas with existing footage**
+  - `Before/After` slider showing static photo vs drone panorama.
+  - `Mini showreel` combining clips for tourism, real estate, eventi.
+  - `Behind the scenes` timeline describing pre-produzione, volo, post-produzione.
+  - Blog post or timeline describing percorso verso patentino + prime esercitazioni con clip embed.
+
+## 5. Suggested Task Backlog
+1. **Copy & Content Update**
+   - Rewrite hero text and CTA in all languages.
+   - Draft services section copy (IT + EN) and define package pricing tiers.
+2. **UI Components**
+   - Build `ServicesComponent` with card layout and icons.
+   - Create `DroneShowcaseComponent` featuring video embeds and CTA to request shooting.
+   - Update `ProjectsComponent` to support category filters and optional video modal.
+3. **Data & Localization**
+   - Add `services.data.ts` and `media.data.ts` with translations.
+   - Update DTOs and translation service usage to cover new sections.
+4. **Lead Capture Enhancements**
+   - Integrate Calendly/Cal.com embed in contact section.
+   - Implement email automation (e.g., Nodemailer backend or external form service) to handle inquiries.
+5. **Performance & Deployment**
+   - Add lazy loading for non-critical components (projects, drone showcase).
+   - Configure video hosting strategy (external embeds + optimized previews) and document asset pipeline in README.
+6. **Validation & Social Proof**
+   - Collect/testimonial carousel with avatars.
+   - Add roadmap section for drone certification progress with expected milestones.
+
+## 6. Next Steps
+- Prioritize hero/services rewrite and drone showcase component to quickly reflect new positioning.
+- Prototype the services section in Figma or directly in Angular, then update translations.
+- Prepare compressed teaser clips and upload longer edits to YouTube/Vimeo for embedding.
+- Document the media pipeline and deployment constraints in the repository README for future contributors.
+


### PR DESCRIPTION
## Summary
- add a documentation page outlining the current Angular portfolio architecture
- provide recommendations for UX, technical enhancements, and drone/video integration
- list a prioritized backlog and next steps to align the site with new service offerings

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d143daf39c832bba93afc322a7948d