### PR TITLE
Update experience data to reflect June 2025 completion

### DIFF
--- a/src/app/data/experiences.data.ts
+++ b/src/app/data/experiences.data.ts
@@ -8,9 +8,9 @@ export const experiencesData: ExperienceFullLangs = {
                 position: 'Software Developer',
                 location: 'Full Remote',
                 startDate: 'Apr 2024',
-                endDate: 'Present',
+                endDate: 'Jun 2025',
                 technologies: 'Spring Boot (3.0), Java 21, JavaFX, Angular (18), Shell, YAML, AngularJS, Python',
-                responsibilities: 'Worked on automating processes and optimizing activities, including bug fixing. Enhanced operational efficiency by streamlining tasks and improving the overall user experience through modern technologies.'
+                responsibilities: 'Concluded the engagement after automating processes and optimizing activities, including bug fixing. Enhanced operational efficiency by streamlining tasks and improving the overall user experience through modern technologies.'
             },
             {
                 position: 'Software Developer',
@@ -67,9 +67,9 @@ export const experiencesData: ExperienceFullLangs = {
                 position: 'Sviluppatore Software',
                 location: 'Full Remote',
                 startDate: 'Apr 2024',
-                endDate: 'In corso',
+                endDate: 'Giu 2025',
                 technologies: 'Spring Boot (3.0), Java 21, JavaFX, Angular (18), Shell, YAML, AngularJS, Python',
-                responsibilities: 'Automatizzazione di processi e ottimizzazione delle attività, inclusa la risoluzione di bug. Miglioramento dell\'efficienza operativa tramite tecnologie moderne.'
+                responsibilities: 'Concluso l\'incarico dopo aver automatizzato processi e ottimizzato le attività, inclusa la risoluzione di bug. Migliorata l\'efficienza operativa grazie all\'uso di tecnologie moderne.'
             },
             {
                 position: 'Sviluppatore Software',
@@ -126,9 +126,9 @@ export const experiencesData: ExperienceFullLangs = {
                 position: 'Software Developer',
                 location: 'Full Remote',
                 startDate: 'Apr 2024',
-                endDate: 'Present',
+                endDate: 'Jun 2025',
                 technologies: 'Spring Boot (3.0), Java 21, JavaFX, Angular (18), Shell, YAML, AngularJS, Python',
-                responsibilities: 'Worked on automating processes and optimizing activities, including bug fixing. Enhanced operational efficiency by streamlining tasks and improving the overall user experience through modern technologies.'
+                responsibilities: 'Concluded the engagement after automating processes and optimizing activities, including bug fixing. Enhanced operational efficiency by streamlining tasks and improving the overall user experience through modern technologies.'
             },
             {
                 position: 'Software Developer',
@@ -185,9 +185,9 @@ export const experiencesData: ExperienceFullLangs = {
                 position: 'Software Developer',
                 location: 'Full Remote',
                 startDate: 'Apr 2024',
-                endDate: 'Present',
+                endDate: 'Jun 2025',
                 technologies: 'Spring Boot (3.0), Java 21, JavaFX, Angular (18), Shell, YAML, AngularJS, Python',
-                responsibilities: 'Worked on automating processes and optimizing activities, including bug fixing. Enhanced operational efficiency by streamlining tasks and improving the overall user experience through modern technologies.'
+                responsibilities: 'Concluded the engagement after automating processes and optimizing activities, including bug fixing. Enhanced operational efficiency by streamlining tasks and improving the overall user experience through modern technologies.'
             },
             {
                 position: 'Software Developer',


### PR DESCRIPTION
## Summary
- replace the open-ended end date for the most recent software developer role with June 2025 across all locales
- reword the associated responsibilities to state that the engagement has concluded in each language

## Testing
- `npm test -- --watch=false` *(fails: existing test suite errors unrelated to this change)*
- `npx ts-node --transpile-only --compiler-options '{"module":"commonjs","moduleResolution":"node"}' <<'TS' ... TS`

------
https://chatgpt.com/codex/tasks/task_e_68deba09cfc0832b88a0da9101a30575