### PR TITLE
feat: redesign navigator timeline

### DIFF
--- a/src/app/components/navigator/navigator.component.html
+++ b/src/app/components/navigator/navigator.component.html
@@ -1,67 +1,97 @@
-<!-- Floating toggle button -->
-<button class="nav-toggle-button" *ngIf="!isOpen" (click)="toggleNavigator()" aria-label="Open navigator">
-  <mat-icon>chevron_left</mat-icon>
-</button>
-
-<!-- Modern, animated, circular floating navbar -->
-<div class="modern-navigator" *ngIf="isOpen">
-  <div class="arrow-container">
-    <!-- Previous button -->
-    <button class="arrow-button" (click)="onPrevious()" aria-label="Previous section"
-      [matTooltip]="getTooltip('prev')" matTooltipPosition="left">
-      <mat-icon>arrow_upward</mat-icon>
-    </button>
-
-    <!-- Next button -->
-    <button class="arrow-button" (click)="onNext()" aria-label="Next section"
-      [matTooltip]="getTooltip('next')" matTooltipPosition="left">
-      <mat-icon>arrow_downward</mat-icon>
-    </button>
-  </div>
-
-  <div class="nav-group">
-    <button class="nav-button" (click)="toggleThemeOptions()" aria-label="Theme selector"
-      [matTooltip]="getTooltip('theme')" matTooltipPosition="left">
-      <mat-icon>{{ getThemeIcon(currentTheme) }}</mat-icon>
-    </button>
-    <div class="option-container" *ngIf="showThemeOptions">
-      <button class="option-button" (click)="changeTheme('light')" aria-label="Light mode"
-        [class.selected]="currentTheme === 'light'">
-        <mat-icon>light_mode</mat-icon>
-      </button>
-      <button class="option-button" (click)="changeTheme('dark')" aria-label="Dark mode"
-        [class.selected]="currentTheme === 'dark'">
-        <mat-icon>dark_mode</mat-icon>
-      </button>
-      <button class="option-button" (click)="changeTheme('blue')" aria-label="Blue mode"
-        [class.selected]="currentTheme === 'blue'">
-        <mat-icon>water_drop</mat-icon>
-      </button>
-      <button class="option-button" (click)="changeTheme('green')" aria-label="Green mode"
-        [class.selected]="currentTheme === 'green'">
-        <mat-icon>eco</mat-icon>
-      </button>
+<aside class="timeline-nav" role="navigation" aria-label="Section timeline"
+  [style.--timeline-progress]="progressPercentage + '%'">
+  <header class="timeline-header">
+    <div class="timeline-summary">
+      <span class="timeline-current-index" aria-hidden="true">
+        {{ (activeSection?.index ?? 0) + 1 | number: '2.0-0' }}
+      </span>
+      <div class="timeline-current-info">
+        <span class="timeline-current-label">{{ activeSection?.label }}</span>
+        <span class="timeline-total" aria-label="Total sections">/{{ totalSections }}</span>
+      </div>
     </div>
+
+    <div class="timeline-actions">
+      <div class="action-group">
+        <button class="action-button" type="button" (click)="toggleThemeOptions()"
+          [attr.aria-label]="getTooltip('theme')" [attr.aria-expanded]="showThemeOptions"
+          matTooltip="{{ getTooltip('theme') }}" matTooltipPosition="below">
+          <mat-icon>{{ getThemeIcon(currentTheme) }}</mat-icon>
+        </button>
+        <div class="action-menu" *ngIf="showThemeOptions">
+          <button class="menu-item" type="button" (click)="changeTheme('light')"
+            [class.is-active]="currentTheme === 'light'" aria-label="Light theme">
+            <mat-icon>light_mode</mat-icon>
+          </button>
+          <button class="menu-item" type="button" (click)="changeTheme('dark')"
+            [class.is-active]="currentTheme === 'dark'" aria-label="Dark theme">
+            <mat-icon>dark_mode</mat-icon>
+          </button>
+          <button class="menu-item" type="button" (click)="changeTheme('blue')"
+            [class.is-active]="currentTheme === 'blue'" aria-label="Blue theme">
+            <mat-icon>water_drop</mat-icon>
+          </button>
+          <button class="menu-item" type="button" (click)="changeTheme('green')"
+            [class.is-active]="currentTheme === 'green'" aria-label="Green theme">
+            <mat-icon>eco</mat-icon>
+          </button>
+        </div>
+      </div>
+
+      <div class="action-group">
+        <button class="action-button" type="button" (click)="toggleLanguageOptions()"
+          [attr.aria-label]="getTooltip('language')" [attr.aria-expanded]="showLanguageOptions"
+          matTooltip="{{ getTooltip('language') }}" matTooltipPosition="below">
+          <span class="lang-label">{{ currentLang | slice:0:3 | uppercase }}</span>
+        </button>
+        <div class="action-menu" *ngIf="showLanguageOptions">
+          <button class="menu-item" type="button" (click)="changeLanguage('en')"
+            [class.is-active]="currentLang === 'en'" aria-label="English">
+            <span class="lang-flag">🇬🇧</span>
+          </button>
+          <button class="menu-item" type="button" (click)="changeLanguage('it')"
+            [class.is-active]="currentLang === 'it'" aria-label="Italiano">
+            <span class="lang-flag">🇮🇹</span>
+          </button>
+          <button class="menu-item" type="button" (click)="changeLanguage('de')"
+            [class.is-active]="currentLang === 'de'" aria-label="Deutsch">
+            <span class="lang-flag">🇩🇪</span>
+          </button>
+          <button class="menu-item" type="button" (click)="changeLanguage('es')"
+            [class.is-active]="currentLang === 'es'" aria-label="Español">
+            <span class="lang-flag">🇪🇸</span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <button class="timeline-arrow" type="button" (click)="onPrevious()" [disabled]="currentSectionIndex === 0"
+    [attr.aria-label]="getTooltip('prev')" matTooltip="{{ getTooltip('prev') }}" matTooltipPosition="left">
+    <mat-icon>arrow_upward</mat-icon>
+  </button>
+
+  <div class="timeline-track">
+    <div class="timeline-progress">
+      <div class="timeline-progress-bar"></div>
+    </div>
+
+    <ol class="timeline-steps">
+      <li *ngFor="let section of sectionItems; trackBy: trackBySection">
+        <button class="timeline-step" type="button" (click)="onSelectSection(section.index)"
+          [class.is-active]="section.index === currentSectionIndex"
+          [attr.aria-current]="section.index === currentSectionIndex ? 'step' : null"
+          matTooltip="{{ section.label }}" matTooltipPosition="left">
+          <span class="timeline-marker" aria-hidden="true">{{ section.index + 1 }}</span>
+          <span class="timeline-label">{{ section.label }}</span>
+        </button>
+      </li>
+    </ol>
   </div>
 
-  <div class="nav-group">
-    <button class="nav-button" (click)="toggleLanguageOptions()" [matTooltip]="getTooltip('language')"
-      matTooltipPosition="left">
-      <span class="lang-label">{{ currentLang | slice:0:3 | uppercase }}</span>
-    </button>
-    <div class="option-container" *ngIf="showLanguageOptions">
-      <button class="option-button" (click)="changeLanguage('en')" aria-label="English">
-        <span class="lang-flag">🇬🇧</span>
-      </button>
-      <button class="option-button" (click)="changeLanguage('it')" aria-label="Italiano">
-        <span class="lang-flag">🇮🇹</span>
-      </button>
-      <button class="option-button" (click)="changeLanguage('de')" aria-label="Deutsch">
-        <span class="lang-flag">🇩🇪</span>
-      </button>
-      <button class="option-button" (click)="changeLanguage('es')" aria-label="Español">
-        <span class="lang-flag">🇪🇸</span>
-      </button>
-    </div>
-  </div>
-</div>
+  <button class="timeline-arrow" type="button" (click)="onNext()"
+    [disabled]="currentSectionIndex === totalSections - 1"
+    [attr.aria-label]="getTooltip('next')" matTooltip="{{ getTooltip('next') }}" matTooltipPosition="left">
+    <mat-icon>arrow_downward</mat-icon>
+  </button>
+</aside>

--- a/src/app/components/navigator/navigator.component.scss
+++ b/src/app/components/navigator/navigator.component.scss
@@ -1,288 +1,466 @@
-@use '../../../styles/variables.scss' as *;
-
-$navigator-bg: #ffffff;
-$navigator-bg-dark: #1f1f1f;
-$navigator-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
-$navigator-icon-size: 24px;
-$navigator-button-size: 48px;
-
-@keyframes float {
-
-    0%,
-    100% {
-        transform: translateY(0);
-    }
-
-    50% {
-        transform: translateY(-4px);
-    }
+:host {
+  display: contents;
 }
 
-.nav-toggle-button {
-    position: fixed;
-    bottom: 30px;
-    right: 30px;
-    width: $navigator-button-size;
-    height: $navigator-button-size;
-    border-radius: 50%;
-    background-color: $navigator-bg;
-    box-shadow: $navigator-shadow;
-    border: none;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    animation: float 3s ease-in-out infinite;
-    cursor: pointer;
-    z-index: 9999;
-
-    mat-icon {
-        position: absolute;
-        font-size: $navigator-icon-size;
-        color: #333;
-    }
-
-    &:hover {
-        background-color: lighten($navigator-bg, 4%);
-    }
+.timeline-nav {
+  --timeline-bg: rgba(255, 255, 255, 0.85);
+  --timeline-border: rgba(255, 255, 255, 0.35);
+  --timeline-text: #1f1f1f;
+  --timeline-muted: rgba(31, 31, 31, 0.55);
+  --timeline-accent: #7c3aed;
+  --timeline-progress: 0%;
+  position: fixed;
+  top: 50%;
+  right: clamp(1.5rem, 4vw, 3.5rem);
+  transform: translateY(-50%);
+  width: clamp(220px, 20vw, 260px);
+  padding: 1.4rem 1.5rem;
+  border-radius: 1.9rem;
+  background: var(--timeline-bg);
+  color: var(--timeline-text);
+  backdrop-filter: blur(18px);
+  box-shadow: 0 22px 55px rgba(15, 15, 15, 0.16);
+  border: 1px solid var(--timeline-border);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  z-index: 999;
 }
 
-.modern-navigator {
-    position: fixed;
-    bottom: 30px;
-    right: 30px;
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-
-    .arrow-container {
-        width: $navigator-button-size - 8;
-        justify-content: center;
-        height: 90px;
-        padding: 4px;
-        background-color: $navigator-bg;
-        box-shadow: $navigator-shadow;
-        border-radius: $navigator-button-size;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        gap: 6px;
-    }
-
-    z-index: 9999;
-
-    .nav-button {
-        width: $navigator-button-size;
-        height: $navigator-button-size;
-        border-radius: 50%;
-        background-color: $navigator-bg;
-        box-shadow: $navigator-shadow;
-        border: none;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        transition: transform 0.2s ease, background-color 0.3s ease;
-
-        &:hover {
-            transform: scale(1.1);
-            background-color: lighten($navigator-bg, 4%);
-        }
-
-        mat-icon {
-            font-size: $navigator-icon-size;
-            color: #333;
-        }
-
-        .lang-label {
-            font-size: 0.9rem;
-            font-weight: 600;
-            color: #333;
-        }
-    }
-
-    .arrow-button {
-        width: $navigator-button-size;
-        height: $navigator-button-size;
-        border-radius: 50%;
-        border: none;
-        background-color: transparent;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        transition: background-color 0.2s ease;
-
-        &:hover {
-            background-color: rgba(0, 0, 0, 0.05);
-        }
-
-        mat-icon {
-            font-size: $navigator-icon-size;
-            color: #333;
-            position: absolute;
-        }
-    }
+:host-context(body.dark-mode) .timeline-nav {
+  --timeline-bg: rgba(15, 15, 15, 0.82);
+  --timeline-border: rgba(255, 255, 255, 0.12);
+  --timeline-text: #f1f3f5;
+  --timeline-muted: rgba(241, 243, 245, 0.6);
+  --timeline-accent: #60a5fa;
+  box-shadow: 0 22px 55px rgba(0, 0, 0, 0.45);
 }
 
-body.dark-mode {
-    .nav-toggle-button {
-        background-color: $navigator-bg-dark;
-
-        mat-icon {
-            color: #f0f0f0;
-        }
-
-        &:hover {
-            background-color: lighten($navigator-bg-dark, 5%);
-        }
-    }
-
-    .modern-navigator {
-
-        .nav-button,
-        .arrow-container {
-            background-color: $navigator-bg-dark;
-        }
-
-        .nav-button:hover,
-        .arrow-button:hover {
-            background-color: lighten($navigator-bg-dark, 5%);
-        }
-
-        .nav-button mat-icon,
-        .nav-button .lang-label,
-        .arrow-button mat-icon {
-            color: #f0f0f0;
-        }
-    }
+:host-context(body.blue-mode) .timeline-nav {
+  --timeline-accent: #38bdf8;
 }
 
-body.blue-mode {
-    .nav-toggle-button {
-        background-color: $navigator-bg;
-
-        &:hover {
-            background-color: lighten($navigator-bg, 4%);
-        }
-    }
-
-    .modern-navigator {
-
-        .nav-button,
-        .arrow-container {
-            background-color: $navigator-bg;
-        }
-
-        .nav-button:hover,
-        .arrow-button:hover {
-            background-color: lighten($navigator-bg, 4%);
-        }
-    }
+:host-context(body.green-mode) .timeline-nav {
+  --timeline-accent: #34d399;
 }
 
-body.green-mode {
-    .nav-toggle-button {
-        background-color: $navigator-bg;
+.timeline-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
 
-        &:hover {
-            background-color: lighten($navigator-bg, 4%);
-        }
-    }
+.timeline-summary {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+}
 
-    .modern-navigator {
+.timeline-current-index {
+  font-size: 1.75rem;
+  font-weight: 700;
+  padding: 0.35rem 0.7rem;
+  border-radius: 1rem;
+  background: rgba(124, 58, 237, 0.15);
+  color: var(--timeline-accent);
+  letter-spacing: 0.05em;
+  line-height: 1;
+  transition: background 0.3s ease, color 0.3s ease;
+}
 
-        .nav-button,
-        .arrow-container {
-            background-color: $navigator-bg;
-        }
+:host-context(body.dark-mode) .timeline-current-index {
+  background: rgba(96, 165, 250, 0.16);
+}
 
-        .nav-button:hover,
-        .arrow-button:hover {
-            background-color: lighten($navigator-bg, 4%);
-        }
-    }
+:host-context(body.blue-mode) .timeline-current-index {
+  background: rgba(56, 189, 248, 0.18);
+}
+
+:host-context(body.green-mode) .timeline-current-index {
+  background: rgba(52, 211, 153, 0.18);
+}
+
+.timeline-current-info {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.2;
+}
+
+.timeline-current-label {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.timeline-total {
+  font-size: 0.75rem;
+  color: var(--timeline-muted);
+  letter-spacing: 0.12em;
+}
+
+.timeline-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.action-group {
+  position: relative;
+}
+
+.action-button {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 1.25rem;
+  border: 1px solid transparent;
+  background: rgba(124, 58, 237, 0.1);
+  color: var(--timeline-text);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.action-button:hover,
+.action-button:focus-visible {
+  background: rgba(124, 58, 237, 0.18);
+  border-color: rgba(124, 58, 237, 0.24);
+  outline: none;
+  transform: translateY(-1px);
+}
+
+:host-context(body.dark-mode) .action-button {
+  background: rgba(96, 165, 250, 0.12);
+}
+
+:host-context(body.dark-mode) .action-button:hover,
+:host-context(body.dark-mode) .action-button:focus-visible {
+  background: rgba(96, 165, 250, 0.2);
+  border-color: rgba(96, 165, 250, 0.35);
+}
+
+.lang-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.action-menu {
+  position: absolute;
+  top: calc(100% + 0.6rem);
+  right: 0;
+  display: grid;
+  grid-auto-flow: column;
+  gap: 0.5rem;
+  padding: 0.55rem;
+  border-radius: 1.1rem;
+  background: var(--timeline-bg);
+  border: 1px solid var(--timeline-border);
+  box-shadow: 0 16px 40px rgba(15, 15, 15, 0.16);
+  z-index: 5;
+}
+
+.menu-item {
+  width: 2.35rem;
+  height: 2.35rem;
+  border-radius: 0.9rem;
+  border: 1px solid transparent;
+  background: transparent;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.menu-item:hover,
+.menu-item:focus-visible {
+  background: rgba(124, 58, 237, 0.12);
+  border-color: rgba(124, 58, 237, 0.35);
+  outline: none;
+  transform: translateY(-1px);
+}
+
+.menu-item.is-active {
+  background: rgba(124, 58, 237, 0.18);
+  border-color: rgba(124, 58, 237, 0.42);
+}
+
+:host-context(body.dark-mode) .menu-item:hover,
+:host-context(body.dark-mode) .menu-item:focus-visible {
+  background: rgba(96, 165, 250, 0.2);
+  border-color: rgba(96, 165, 250, 0.4);
+}
+
+:host-context(body.dark-mode) .menu-item.is-active {
+  background: rgba(96, 165, 250, 0.24);
+  border-color: rgba(96, 165, 250, 0.45);
+}
+
+.timeline-arrow {
+  width: 2.6rem;
+  height: 2.6rem;
+  border-radius: 1.3rem;
+  border: 1px solid transparent;
+  background: rgba(124, 58, 237, 0.12);
+  color: var(--timeline-text);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  align-self: center;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.timeline-arrow:hover:not(:disabled),
+.timeline-arrow:focus-visible:not(:disabled) {
+  background: rgba(124, 58, 237, 0.2);
+  border-color: rgba(124, 58, 237, 0.35);
+  transform: translateY(-2px);
+  outline: none;
+}
+
+.timeline-arrow:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.timeline-track {
+  display: flex;
+  align-items: stretch;
+  gap: 1.4rem;
+}
+
+.timeline-progress {
+  position: relative;
+  width: 5px;
+  border-radius: 999px;
+  background: linear-gradient(180deg, rgba(124, 58, 237, 0.12), rgba(124, 58, 237, 0.28));
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.timeline-progress-bar {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: var(--timeline-progress);
+  background: linear-gradient(180deg, rgba(124, 58, 237, 0.8), rgba(124, 58, 237, 0.3));
+  transition: height 0.4s ease;
+}
+
+:host-context(body.dark-mode) .timeline-progress {
+  background: linear-gradient(180deg, rgba(96, 165, 250, 0.1), rgba(96, 165, 250, 0.28));
+}
+
+:host-context(body.dark-mode) .timeline-progress-bar {
+  background: linear-gradient(180deg, rgba(96, 165, 250, 0.9), rgba(96, 165, 250, 0.4));
+}
+
+:host-context(body.blue-mode) .timeline-progress {
+  background: linear-gradient(180deg, rgba(56, 189, 248, 0.1), rgba(56, 189, 248, 0.28));
+}
+
+:host-context(body.blue-mode) .timeline-progress-bar {
+  background: linear-gradient(180deg, rgba(56, 189, 248, 0.95), rgba(56, 189, 248, 0.4));
+}
+
+:host-context(body.green-mode) .timeline-progress {
+  background: linear-gradient(180deg, rgba(52, 211, 153, 0.1), rgba(52, 211, 153, 0.28));
+}
+
+:host-context(body.green-mode) .timeline-progress-bar {
+  background: linear-gradient(180deg, rgba(52, 211, 153, 0.9), rgba(52, 211, 153, 0.4));
+}
+
+.timeline-steps {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.timeline-step {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--timeline-text);
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+}
+
+.timeline-step:hover,
+.timeline-step:focus-visible {
+  background: rgba(124, 58, 237, 0.12);
+  border-color: rgba(124, 58, 237, 0.18);
+  outline: none;
+}
+
+.timeline-step.is-active {
+  background: rgba(124, 58, 237, 0.18);
+  border-color: rgba(124, 58, 237, 0.3);
+  transform: translateX(-4px);
+}
+
+.timeline-marker {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: rgba(124, 58, 237, 0.12);
+  color: var(--timeline-text);
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.3s ease, color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.timeline-step.is-active .timeline-marker {
+  background: var(--timeline-accent);
+  color: #ffffff;
+  box-shadow: 0 10px 22px rgba(124, 58, 237, 0.45);
+}
+
+.timeline-label {
+  position: absolute;
+  left: auto;
+  right: calc(100% + 0.85rem);
+  top: 50%;
+  transform: translateY(-50%) translateX(12px);
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: var(--timeline-bg);
+  color: var(--timeline-text);
+  box-shadow: 0 16px 40px rgba(15, 15, 15, 0.12);
+  white-space: nowrap;
+  font-size: 0.75rem;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.timeline-step:hover .timeline-label,
+.timeline-step.is-active .timeline-label {
+  opacity: 1;
+  transform: translateY(-50%) translateX(0);
 }
 
 .lang-flag {
-    font-size: 1.2rem;
-    margin-right: 8px;
+  font-size: 1.2rem;
 }
 
-.nav-group {
-    position: relative;
+@media (max-width: 1024px) {
+  .timeline-nav {
+    right: clamp(1rem, 3vw, 2rem);
+  }
 }
 
-.option-container {
-    position: absolute;
-    top: 50%;
-    right: calc(100% + 8px);
-    transform: translateY(-50%);
-    display: flex;
-    gap: 6px;
-    background: $navigator-bg;
-    padding: 4px 6px;
-    border-radius: 2rem;
-    box-shadow: $navigator-shadow;
+@media (max-width: 900px) {
+  .timeline-nav {
+    top: auto;
+    bottom: 1.2rem;
+    left: 50%;
+    right: auto;
+    transform: translateX(-50%);
+    width: min(92vw, 560px);
+    padding: 1rem 1.2rem;
+    gap: 0.9rem;
+  }
+
+  .timeline-header {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.75rem;
+  }
+
+  .timeline-summary {
+    justify-content: space-between;
+  }
+
+  .timeline-actions {
+    justify-content: flex-end;
+  }
+
+  .timeline-track {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.75rem;
+  }
+
+  .timeline-progress {
+    width: 100%;
+    height: 5px;
+  }
+
+  .timeline-progress-bar {
+    height: 100%;
+    width: var(--timeline-progress);
+    transition: width 0.4s ease;
+  }
+
+  .timeline-steps {
+    flex-direction: row;
+    gap: 0.75rem;
+    overflow-x: auto;
+    padding-bottom: 0.25rem;
+    scrollbar-width: thin;
+  }
+
+  .timeline-steps::-webkit-scrollbar {
+    height: 4px;
+  }
+
+  .timeline-steps::-webkit-scrollbar-thumb {
+    background: rgba(124, 58, 237, 0.4);
+    border-radius: 999px;
+  }
+
+  .timeline-step {
+    flex-direction: column;
     align-items: center;
-    z-index: 1;
+    gap: 0.45rem;
+    padding: 0.65rem 0.9rem;
+    min-width: 120px;
+    transform: none !important;
+  }
+
+  .timeline-step.is-active {
+    border-color: rgba(124, 58, 237, 0.4);
+  }
+
+  .timeline-marker {
+    width: 2.4rem;
+    height: 2.4rem;
+  }
+
+  .timeline-label {
+    position: static;
+    transform: none;
+    background: transparent;
+    box-shadow: none;
+    opacity: 1;
+    pointer-events: auto;
+    font-weight: 600;
+    font-size: 0.85rem;
+  }
 }
 
-body.dark-mode {
-    .option-container {
-        background: $navigator-bg-dark;
-    }
+@media (max-width: 600px) {
+  .timeline-nav {
+    width: min(96vw, 500px);
+    padding: 0.85rem 1rem;
+  }
 
-    .option-button mat-icon,
-    .option-button .lang-flag {
-        position: absolute;
-        color: #f0f0f0;
-    }
-}
-
-.option-button {
-    width: 32px;
-    height: 32px;
-    border-radius: 50%;
-    border: none;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background-color: transparent;
-    transition: background-color 0.2s ease;
-
-    &:hover {
-        background-color: rgba(0, 0, 0, 0.05);
-    }
-
-    mat-icon {
-        position: absolute;
-        font-size: 20px;
-        color: #333;
-    }
-
-    .section-number {
-        position: absolute;
-        font-size: 0.9rem;
-        font-weight: 600;
-        color: #333;
-    }
-
-    &.selected {
-        background-color: rgba(0, 0, 0, 0.1);
-    }
-}
-
-body.dark-mode {
-    .option-button:hover {
-        background-color: rgba(255, 255, 255, 0.1);
-    }
-
-    .option-button mat-icon,
-    .option-button .section-number {
-        position: absolute;
-        color: #f0f0f0;
-    }
-
-    .option-button.selected {
-        background-color: rgba(255, 255, 255, 0.2);
-    }
+  .timeline-step {
+    min-width: 100px;
+  }
 }

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -9,6 +9,7 @@
   <div #section><app-contact-me></app-contact-me></div>
 
   <app-navigator [totalSections]="totalSections" [currentSectionIndex]="currentSectionIndex"
-    (navigateNext)="navigateNext()" (navigatePrevious)="navigatePrevious()">
+    (navigateNext)="navigateNext()" (navigatePrevious)="navigatePrevious()"
+    (navigateToSection)="navigateTo($event)">
   </app-navigator>
 </div>

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -83,6 +83,13 @@ export class HomeComponent implements AfterViewInit, OnInit {
     }
   }
 
+  navigateTo(index: number): void {
+    if (this.viewInitialized && index !== this.currentSectionIndex && index >= 0 && index < this.totalSections) {
+      this.currentSectionIndex = index;
+      this.scrollToSection(index);
+    }
+  }
+
   scrollToSection(index: number): void {
     const section = this.sections.toArray()[index].nativeElement;
     section.scrollIntoView({ behavior: 'smooth', block: 'start' });


### PR DESCRIPTION
## Summary
- replace the floating navigator with a fixed timeline sidebar that lists sections, highlights the active step, and exposes dedicated navigation events
- surface theme and language toggles inside the timeline header while keeping tooltip helpers and derived section labels per locale
- refresh the styling with animated progress, active state tooltips, and a responsive horizontal layout for smaller screens

## Testing
- `npm run build` *(fails: Angular CLI cannot download Google Fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68deba2c1374832b83daea75f21286a8