### PR TITLE
Adjust Express server routing for SSR assets

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -20,13 +20,13 @@ export function app(): express.Express {
   // Example Express Rest API endpoints
   // server.get('/api/**', (req, res) => { });
   // Serve static files from /browser
-  server.get('**', express.static(browserDistFolder, {
+  server.use('/', express.static(browserDistFolder, {
     maxAge: '1y',
     index: 'index.html',
   }));
 
   // All regular routes use the Angular engine
-  server.get('**', (req, res, next) => {
+  server.get('*', (req, res, next) => {
     const { protocol, originalUrl, baseUrl, headers } = req;
 
     commonEngine


### PR DESCRIPTION
## Summary
- update the Express server to use an explicit base path when serving static browser assets
- align the catch-all SSR route with Angular's recommended `*` matcher while preserving the render logic

## Testing
- npm run build *(fails: Angular CLI cannot inline fonts from fonts.googleapis.com and returns HTTP 403)*
- npm run serve:ssr:portfolio *(fails: build artifacts are missing because the SSR build could not be produced)*

------
https://chatgpt.com/codex/tasks/task_e_68e181676850832bbab24e2ebe6544d8