### PR TITLE
Adjust education component spec to match language-specific data

### DIFF
--- a/src/app/components/education/education.component.spec.ts
+++ b/src/app/components/education/education.component.spec.ts
@@ -33,8 +33,10 @@ describe('EducationComponent', () => {
    * Verifies that the education list data is initialized correctly.
    */
   it('should initialize educationList correctly', () => {
-    expect(component.educationList).toEqual(educationData);
-    expect(component.educationList.education.length).toBeGreaterThan(0);
+    const expectedEducation = educationData.en;
+
+    expect(component.educationList).toEqual(expectedEducation);
+    expect(component.educationList.education.length).toBe(educationData.en.education.length);
   });
 
   /**


### PR DESCRIPTION
## Summary
- update the education component spec to compare the initialized data against the English education dataset
- ensure the education list length assertion matches the localized data size

## Testing
- `npm run test -- --include src/app/components/education/education.component.spec.ts` *(fails: existing TypeScript errors in other specs and missing Chrome binary)*

------
https://chatgpt.com/codex/tasks/task_e_68e2740d622c832b98874ead9c399a79