### PR TITLE
Fix experiences component spec translation expectations

### DIFF
--- a/src/app/components/experiences/experiences.component.spec.ts
+++ b/src/app/components/experiences/experiences.component.spec.ts
@@ -1,10 +1,20 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ExperiencesComponent } from './experiences.component';
+import { of } from 'rxjs';
 import { experiencesData } from '../../data/experiences.data';
+import { TranslationService } from '../../services/translation.service';
 
 /**
  * Unit tests for ExperiencesComponent.
  */
+class MockTranslationService {
+  currentLanguage$ = of<'en'>('en');
+
+  getTranslatedData<T>(data: { [key: string]: T }): T {
+    return data['en'];
+  }
+}
+
 describe('ExperiencesComponent', () => {
   let component: ExperiencesComponent;
   let fixture: ComponentFixture<ExperiencesComponent>;
@@ -12,7 +22,10 @@ describe('ExperiencesComponent', () => {
   // Initialize the test environment and component
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ExperiencesComponent]
+      imports: [ExperiencesComponent],
+      providers: [
+        { provide: TranslationService, useClass: MockTranslationService }
+      ]
     }).compileComponents();
 
     fixture = TestBed.createComponent(ExperiencesComponent);
@@ -27,8 +40,10 @@ describe('ExperiencesComponent', () => {
 
   // Verify the data is correctly initialized
   it('should initialize experiences data correctly', () => {
-    expect(component.experiences).toEqual(experiencesData);
-    expect(component.experiences.experiences.length).toBeGreaterThan(0);
+    const expectedExperiences = experiencesData.en;
+    expect(component.experiences).toEqual(expectedExperiences);
+    expect(component.experiences.experiences.length).toBe(expectedExperiences.experiences.length);
+    expect(component.experiences.title).toBe(expectedExperiences.title);
   });
 
   // Verify the template renders the experiences correctly


### PR DESCRIPTION
## Summary
- mock the translation service in the experiences component test to control the emitted language
- adjust expectations to compare the component data with the English dataset used by the mock

## Testing
- npm run test -- --include src/app/components/experiences/experiences.component.spec.ts --watch=false *(fails: unrelated TypeScript errors in other specs and missing Chrome binary)*

------
https://chatgpt.com/codex/tasks/task_e_68e2740cd5dc832bba71148a476a8dd8