### PR TITLE
Use ReturnType for hero component timeouts

### DIFF
--- a/src/app/components/hero/hero.component.ts
+++ b/src/app/components/hero/hero.component.ts
@@ -36,7 +36,7 @@ export class HeroComponent implements OnInit {
   isAnimating = false;
 
   // Store the timeout references to be able to clear them
-  timeoutIds: (number | NodeJS.Timeout)[] = []; // This will store both browser and Node.js timeout ids
+  timeoutIds: ReturnType<typeof setTimeout>[] = []; // This will store both browser and Node.js timeout ids
 
   constructor(private translationService: TranslationService) { }
 


### PR DESCRIPTION
## Summary
- update the hero component's timeout storage to use `ReturnType<typeof setTimeout>` so the type aligns with both browser and Node environments

## Testing
- npm run test -- --include src/app/components/hero/hero.component.spec.ts *(fails: Angular CLI reports pre-existing TypeScript errors in other specs and cannot launch Chrome due to missing binary)*

------
https://chatgpt.com/codex/tasks/task_e_68e2740a3ffc832b923aec2535537eb7