### PR TITLE
Configure Karma to use Chrome Headless

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -91,6 +91,7 @@
         "test": {
           "builder": "@angular-devkit/build-angular:karma",
           "options": {
+            "karmaConfig": "karma.conf.cjs",
             "polyfills": [
               "zone.js",
               "zone.js/testing"
@@ -115,5 +116,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/karma.conf.cjs
+++ b/karma.conf.cjs
@@ -1,0 +1,52 @@
+const { existsSync } = require('node:fs');
+const { join } = require('node:path');
+
+const chromeExecutablePath =
+  process.env.CHROME_BIN ||
+  (existsSync(join(__dirname, 'node_modules', 'puppeteer'))
+    ? require('puppeteer').executablePath()
+    : undefined);
+
+module.exports = function (config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage'),
+      require('@angular-devkit/build-angular/plugins/karma'),
+    ],
+    client: {
+      jasmine: {},
+      clearContext: false,
+    },
+    jasmineHtmlReporter: {
+      suppressAll: true,
+    },
+    coverageReporter: {
+      dir: join(__dirname, './coverage/portfolio'),
+      subdir: '.',
+      reporters: [
+        { type: 'html' },
+        { type: 'text-summary' },
+      ],
+    },
+    reporters: ['progress', 'kjhtml'],
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: true,
+    browsers: ['ChromeHeadless'],
+    singleRun: false,
+    restartOnFileChange: true,
+    customLaunchers: {
+      ChromeHeadless: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage'],
+        executablePath: chromeExecutablePath,
+      },
+    },
+  });
+};

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
+    "test:headless": "CHROME_BIN=\"$(node -p \"require('puppeteer').executablePath()\")\" ng test --watch=false --browsers=ChromeHeadless",
     "serve:ssr:portfolio": "node dist/portfolio/server/server.mjs"
   },
   "private": true,
@@ -50,6 +51,7 @@
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.1.0",
     "ngx-build-plus": "^18.0.0",
+    "puppeteer": "^23.7.0",
     "sass": "^1.80.7",
     "three": "^0.177.0",
     "typescript": "~5.5.2"


### PR DESCRIPTION
## Summary
- add a dedicated Karma configuration that defaults to ChromeHeadless and relies on Puppeteer when available
- wire the Angular test target to the new Karma config and provide an npm script for headless execution
- declare Puppeteer as a development dependency to supply a Chromium binary when installs are permitted

## Testing
- npm run test -- --watch=false --browsers=ChromeHeadless *(fails: existing unit tests and missing Chrome binary prevent a clean run)*
- npm install --save-dev puppeteer *(fails: registry responded with 403 Forbidden in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2740925f8832bae1d900f12c3471d