### PR TITLE
Update stats component test to use explicit language

### DIFF
--- a/src/app/components/stats/stats.component.spec.ts
+++ b/src/app/components/stats/stats.component.spec.ts
@@ -47,7 +47,7 @@ describe('StatsComponent', () => {
    * Verifies that calculateStats computes correct statistics based on test data.
    */
   it('should calculate correct stats', () => {
-    const stats: StatsItem = component.calculateStats(experiencesData.experiences, projects.projects);
+    const stats: StatsItem = component.calculateStats(experiencesData.en.experiences, projects.en.projects);
 
     expect(stats.hours).toContain('hours');
     expect(stats.months).toContain('months');
@@ -96,7 +96,7 @@ describe('StatsComponent', () => {
       mostUsed: 'Java, Angular, SQL, Node.js'
     };
 
-    component.prepareStatistics();
+    component.prepareStatistics('en');
 
     expect(component.statistics.length).toBe(4);
     expect(component.statistics[0].value).toBe('4000 hours');


### PR DESCRIPTION
## Summary
- call `prepareStatistics` with the English language key in the stats component spec
- align the statistics test fixtures with the English dataset when invoking `calculateStats`

## Testing
- `npm run test -- --include src/app/components/stats/stats.component.spec.ts` *(fails: existing TypeScript errors in unrelated specs and missing Chrome binary)*

------
https://chatgpt.com/codex/tasks/task_e_68e2740a78b0832ba2df456cec8eb25f