### PR TITLE
Update Karma headless launcher name

### DIFF
--- a/karma.conf.cjs
+++ b/karma.conf.cjs
@@ -38,11 +38,11 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['ChromeHeadless'],
+    browsers: ['ChromeHeadlessPuppeteer'],
     singleRun: false,
     restartOnFileChange: true,
     customLaunchers: {
-      ChromeHeadless: {
+      ChromeHeadlessPuppeteer: {
         base: 'ChromeHeadless',
         flags: ['--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage'],
         executablePath: chromeExecutablePath,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
-    "test:headless": "CHROME_BIN=\"$(node -p \"require('puppeteer').executablePath()\")\" ng test --watch=false --browsers=ChromeHeadless",
+    "test:headless": "CHROME_BIN=\"$(node -p \"require('puppeteer').executablePath()\")\" ng test --watch=false --browsers=ChromeHeadlessPuppeteer",
     "serve:ssr:portfolio": "node dist/portfolio/server/server.mjs"
   },
   "private": true,


### PR DESCRIPTION
## Summary
- rename the Karma custom launcher to ChromeHeadlessPuppeteer and update the browsers list to match
- align the headless test npm script with the new launcher name

## Testing
- npm run test:headless *(fails: missing puppeteer package in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e27a3a9798832bbddc5055739d70af