### PR TITLE
Document headless test script in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ This repository contains a portfolio application built with **Angular 18**. It u
 - `npm start` – run the dev server
 - `npm run build` – build the project
 - `npm test` – execute unit tests
+- `npm run test:headless` – run the CI-friendly headless Chrome test suite
 - `npm run serve:ssr:portfolio` – serve the built SSR bundle
 
 ### Server-side Rendering


### PR DESCRIPTION
## Summary
- note the `npm run test:headless` command in the README scripts list so contributors can discover the CI-friendly test runner

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e2839db320832baa8265cfbc41c720