### PR TITLE
Guard scrollToSection against missing sections

### DIFF
--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -135,7 +135,13 @@ export class HomeComponent implements AfterViewInit, OnInit {
   }
 
   scrollToSection(index: number): void {
-    const section = this.sections.toArray()[index].nativeElement;
-    section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    const sections = this.sections?.toArray() ?? [];
+    const section = sections[index];
+
+    if (!section) {
+      return;
+    }
+
+    section.nativeElement.scrollIntoView({ behavior: 'smooth', block: 'start' });
   }
 }


### PR DESCRIPTION
## Summary
- prevent scrollToSection from throwing when requested section is missing
- return early if a section reference is unavailable before scrolling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2894b5388832b98b3825d17da46b9