### PR TITLE
Add NoopAnimationsModule to HomeComponent tests

### DIFF
--- a/src/app/pages/home/home.component.spec.ts
+++ b/src/app/pages/home/home.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HomeComponent } from './home.component';
 import { ElementRef } from '@angular/core';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('HomeComponent', () => {
   let component: HomeComponent;
@@ -8,7 +9,7 @@ describe('HomeComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HomeComponent]
+      imports: [HomeComponent, NoopAnimationsModule]
     }).compileComponents();
 
     fixture = TestBed.createComponent(HomeComponent);


### PR DESCRIPTION
## Summary
- import NoopAnimationsModule into the HomeComponent spec
- include NoopAnimationsModule in the testing module configuration

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2894b876c832ba5fa136985bbd7da