### PR TITLE
Ensure theme toggle test initializes light mode baseline

### DIFF
--- a/src/app/components/navigator/themeswitch/themeswitch.component.spec.ts
+++ b/src/app/components/navigator/themeswitch/themeswitch.component.spec.ts
@@ -45,6 +45,9 @@ describe('ThemeswitchComponent', () => {
    * Verifies the toggleTheme function works correctly.
    */
   it('should toggle theme and update localStorage', () => {
+    localStorage.setItem('darkMode', 'false');
+    component.ngOnInit();
+
     spyOn(localStorage, 'setItem');
 
     component.toggleTheme();


### PR DESCRIPTION
## Summary
- initialize the theme toggle unit test to a known light-mode state before exercising the toggle

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2894c30a8832ba7c2be07f4692491