### PR TITLE
Add NoopAnimationsModule to contact component tests

### DIFF
--- a/src/app/components/contact-me/contact-me.component.spec.ts
+++ b/src/app/components/contact-me/contact-me.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ContactMeComponent } from './contact-me.component';
 import { SocialComponent } from '../social/social.component';
 
@@ -14,7 +15,7 @@ describe('ContactMeComponent', () => {
    */
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ContactMeComponent, SocialComponent]
+      imports: [ContactMeComponent, SocialComponent, NoopAnimationsModule]
     }).compileComponents();
 
     fixture = TestBed.createComponent(ContactMeComponent);


### PR DESCRIPTION
## Summary
- add NoopAnimationsModule import to the contact-me component spec
- include NoopAnimationsModule in the TestBed imports to disable real animations during testing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e28c8fc190832bae3b95ba4504be33