### PR TITLE
Refactor translation service spec to avoid nested subscriptions

### DIFF
--- a/src/app/services/translation.service.spec.ts
+++ b/src/app/services/translation.service.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { firstValueFrom } from 'rxjs';
 import { TranslationService } from './translation.service';
 
 describe('TranslationService', () => {
@@ -28,16 +29,14 @@ describe('TranslationService', () => {
     });
   });
 
-  it('should support german and spanish languages', (done: DoneFn) => {
+  it('should support german and spanish languages', async () => {
     service.setLanguage('de');
-    service.currentLanguage$.subscribe(lang => {
-      expect(lang).toBe('de');
-      service.setLanguage('es');
-      service.currentLanguage$.subscribe(lang2 => {
-        expect(lang2).toBe('es');
-        done();
-      });
-    });
+    const german = await firstValueFrom(service.currentLanguage$);
+    expect(german).toBe('de');
+
+    service.setLanguage('es');
+    const spanish = await firstValueFrom(service.currentLanguage$);
+    expect(spanish).toBe('es');
   });
 
   it('should return the correct translated data for the current language', () => {


### PR DESCRIPTION
## Summary
- replace the translation service german/spanish spec's nested subscriptions with an async `firstValueFrom` flow to avoid stale BehaviorSubject emissions

## Testing
- npm run test:headless *(fails: Cannot find module 'puppeteer'; ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e28c8f2244832b961daaec59bdd78a