### PR TITLE
Update Karma Chrome launcher to use Puppeteer when available

### DIFF
--- a/karma.conf.cjs
+++ b/karma.conf.cjs
@@ -1,11 +1,25 @@
-const { existsSync } = require('node:fs');
 const { join } = require('node:path');
 
-const chromeExecutablePath =
-  process.env.CHROME_BIN ||
-  (existsSync(join(__dirname, 'node_modules', 'puppeteer'))
-    ? require('puppeteer').executablePath()
-    : undefined);
+let chromeExecutablePath = process.env.CHROME_BIN;
+
+try {
+  chromeExecutablePath = require('puppeteer').executablePath();
+} catch (error) {
+  try {
+    const puppeteerPath = require.resolve('puppeteer');
+    chromeExecutablePath = require(puppeteerPath).executablePath();
+  } catch (resolveError) {
+    if (resolveError.code !== 'MODULE_NOT_FOUND') {
+      throw resolveError;
+    }
+  }
+}
+
+if (chromeExecutablePath) {
+  process.env.CHROME_BIN = chromeExecutablePath;
+} else {
+  delete process.env.CHROME_BIN;
+}
 
 module.exports = function (config) {
   config.set({


### PR DESCRIPTION
## Summary
- initialize the Karma Chrome launcher from the existing CHROME_BIN environment variable
- prefer Puppeteer's bundled Chromium when the dependency is installed and sync the environment variable accordingly
- fall back to the previous environment configuration when Puppeteer is unavailable

## Testing
- not run (configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68e297c46dfc832b95d3ac35f0cd3b17