### PR TITLE
Hide navigator arrows at section edges

### DIFF
--- a/src/app/components/navigator/navigator.component.html
+++ b/src/app/components/navigator/navigator.component.html
@@ -7,13 +7,13 @@
 <div class="modern-navigator" *ngIf="isOpen">
   <div class="arrow-container">
     <!-- Previous button -->
-    <button class="arrow-button" (click)="onPrevious()" aria-label="Previous section"
+    <button class="arrow-button" *ngIf="currentSectionIndex > 0" (click)="onPrevious()" aria-label="Previous section"
       [matTooltip]="getTooltip('prev')" matTooltipPosition="left">
       <mat-icon>arrow_upward</mat-icon>
     </button>
 
     <!-- Next button -->
-    <button class="arrow-button" (click)="onNext()" aria-label="Next section"
+    <button class="arrow-button" *ngIf="currentSectionIndex < totalSections - 1" (click)="onNext()" aria-label="Next section"
       [matTooltip]="getTooltip('next')" matTooltipPosition="left">
       <mat-icon>arrow_downward</mat-icon>
     </button>


### PR DESCRIPTION
## Summary
- hide the previous arrow when already at the first section
- hide the next arrow when already at the last section while keeping existing bindings intact

## Testing
- npx ng test --watch=false --include src/app/components/navigator/navigator.component.spec.ts *(fails: ChromeHeadless missing libatk-1.0.so.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e29a904708832b9a47e41d569257ea