### PR TITLE
Fix headless Chrome launcher configuration

### DIFF
--- a/karma.conf.cjs
+++ b/karma.conf.cjs
@@ -7,7 +7,18 @@ const chromeExecutablePath =
     ? require('puppeteer').executablePath()
     : undefined);
 
+const chromeHeadlessFlags = ['--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage'];
+
+if (!process.env.CHROME_BIN && chromeExecutablePath) {
+  process.env.CHROME_BIN = chromeExecutablePath;
+}
+
 module.exports = function (config) {
+  const requestedBrowsers = config.browsers && config.browsers.length > 0 ? config.browsers : undefined;
+  const browsers = (requestedBrowsers || ['ChromeHeadlessNoSandbox']).map((browser) =>
+    browser === 'ChromeHeadless' ? 'ChromeHeadlessNoSandbox' : browser,
+  );
+
   config.set({
     basePath: '',
     frameworks: ['jasmine', '@angular-devkit/build-angular'],
@@ -38,13 +49,18 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['ChromeHeadlessPuppeteer'],
+    browsers,
     singleRun: false,
     restartOnFileChange: true,
     customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: 'ChromeHeadless',
+        flags: chromeHeadlessFlags,
+        executablePath: chromeExecutablePath,
+      },
       ChromeHeadlessPuppeteer: {
         base: 'ChromeHeadless',
-        flags: ['--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage'],
+        flags: chromeHeadlessFlags,
         executablePath: chromeExecutablePath,
       },
     },


### PR DESCRIPTION
## Summary
- default Karma to a ChromeHeadless launcher that always applies no-sandbox flags
- normalize CLI browser selections so ChromeHeadless resolves to the hardened launcher
- share browser flags between Puppeteer and default launchers while preserving CHROME_BIN detection

## Testing
- CI=true npm test -- --watch=false --browsers=ChromeHeadless *(fails: missing libatk-1.0.so.0 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e298910b90832ba8aea48ce2759e69