### PR TITLE
Fix skills component spec imports

### DIFF
--- a/src/app/components/skills/skills.component.spec.ts
+++ b/src/app/components/skills/skills.component.spec.ts
@@ -11,8 +11,7 @@ describe('SkillsComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [CommonModule],
-      declarations: [SkillsComponent],
+      imports: [CommonModule, SkillsComponent],
     });
 
     fixture = TestBed.createComponent(SkillsComponent);


### PR DESCRIPTION
## Summary
- update the SkillsComponent spec to import the standalone component rather than declare it

## Testing
- npm run test:headless -- --include src/app/components/skills/skills.component.spec.ts *(fails: ChromeHeadless cannot start because libatk-1.0.so.0 is missing in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e29a9000fc832bbb3ee6fa62a6ad10