### PR TITLE
Ensure Karma CLI browsers use no-sandbox launcher

### DIFF
--- a/karma.conf.cjs
+++ b/karma.conf.cjs
@@ -28,7 +28,16 @@ if (!process.env.CHROME_BIN && chromeExecutablePath) {
 }
 
 module.exports = function (config) {
-  const requestedBrowsers = config.browsers && config.browsers.length > 0 ? config.browsers : undefined;
+  const requestedBrowsers =
+    config.browsers && config.browsers.length > 0
+      ? Array.isArray(config.browsers)
+        ? config.browsers
+        : String(config.browsers)
+            .split(',')
+            .map((browser) => browser.trim())
+            .filter(Boolean)
+      : undefined;
+
   const browsers = (requestedBrowsers || ['ChromeHeadlessNoSandbox']).map((browser) =>
     browser === 'ChromeHeadless' ? 'ChromeHeadlessNoSandbox' : browser,
   );


### PR DESCRIPTION
## Summary
- normalize Karma CLI browser arguments so they are treated as arrays
- keep mapping ChromeHeadless to the custom no-sandbox launcher even when browsers are passed via CLI

## Testing
- CI=true npm test -- --watch=false --browsers=ChromeHeadless *(fails: missing libatk-1.0.so.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e29c0e4e6c832b8c9edf4e593b381e