### PR TITLE
chore: harden ChromeHeadless launcher

### DIFF
--- a/karma.conf.cjs
+++ b/karma.conf.cjs
@@ -21,7 +21,12 @@ if (chromeExecutablePath) {
   delete process.env.CHROME_BIN;
 }
 
-const chromeHeadlessFlags = ['--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage'];
+const chromeHeadlessFlags = [
+  '--no-sandbox',
+  '--disable-gpu',
+  '--disable-dev-shm-usage',
+  '--disable-setuid-sandbox',
+];
 
 if (!process.env.CHROME_BIN && chromeExecutablePath) {
   process.env.CHROME_BIN = chromeExecutablePath;
@@ -38,8 +43,8 @@ module.exports = function (config) {
             .filter(Boolean)
       : undefined;
 
-  const browsers = (requestedBrowsers || ['ChromeHeadlessNoSandbox']).map((browser) =>
-    browser === 'ChromeHeadless' ? 'ChromeHeadlessNoSandbox' : browser,
+  const browsers = (requestedBrowsers || ['ChromeHeadless']).map((browser) =>
+    browser === 'ChromeHeadlessNoSandbox' ? 'ChromeHeadless' : browser,
   );
 
   config.set({
@@ -76,16 +81,31 @@ module.exports = function (config) {
     singleRun: false,
     restartOnFileChange: true,
     customLaunchers: {
-      ChromeHeadlessNoSandbox: {
+      ChromeHeadless: {
         base: 'ChromeHeadless',
         flags: chromeHeadlessFlags,
         executablePath: chromeExecutablePath,
       },
-      ChromeHeadlessPuppeteer: {
+      ChromeHeadlessNoSandbox: {
         base: 'ChromeHeadless',
         flags: chromeHeadlessFlags,
         executablePath: chromeExecutablePath,
       },
     },
   });
+
+  const chromeLauncherModule = require('karma-chrome-launcher');
+  const chromeHeadlessProvider = chromeLauncherModule['launcher:ChromeHeadless'];
+
+  config.plugins.push({
+    'launcher:ChromeHeadlessBase': chromeHeadlessProvider,
+  });
+
+  if (config.customLaunchers?.ChromeHeadless) {
+    config.customLaunchers.ChromeHeadless.base = 'ChromeHeadlessBase';
+  }
+
+  if (config.customLaunchers?.ChromeHeadlessNoSandbox) {
+    config.customLaunchers.ChromeHeadlessNoSandbox.base = 'ChromeHeadlessBase';
+  }
 };


### PR DESCRIPTION
## Summary
- add the disable-setuid-sandbox switch to the shared Chrome headless flags
- expose a custom ChromeHeadless launcher that reuses the shared flags and puppeteer binary
- keep ChromeHeadlessNoSandbox as an alias while wiring the launcher through a base provider override

## Testing
- `CI=true npm test -- --watch=false --browsers=ChromeHeadless --progress=false` *(fails: missing libatk-1.0.so.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e29da18030832ba5e10bdaeeee7372