### PR TITLE
Fix wheel scroll tests to mock preventDefault

### DIFF
--- a/src/app/pages/home/home.component.spec.ts
+++ b/src/app/pages/home/home.component.spec.ts
@@ -31,7 +31,7 @@ describe('HomeComponent', () => {
     } as any; // Mock della sezione per il test
     component.currentSectionIndex = 0;
 
-    component.onWheelScroll({ deltaY: 1 } as WheelEvent); // Simula scroll down
+    component.onWheelScroll({ deltaY: 1, preventDefault: () => {} } as WheelEvent); // Simula scroll down
     expect(component.currentSectionIndex).toBe(1);
   });
 
@@ -44,7 +44,7 @@ describe('HomeComponent', () => {
     } as any;
     component.currentSectionIndex = 1;
 
-    component.onWheelScroll({ deltaY: 1 } as WheelEvent); // Simula scroll down
+    component.onWheelScroll({ deltaY: 1, preventDefault: () => {} } as WheelEvent); // Simula scroll down
     expect(component.currentSectionIndex).toBe(1); // Dovrebbe restare sull'ultima sezione
   });
 
@@ -57,7 +57,7 @@ describe('HomeComponent', () => {
     } as any;
     component.currentSectionIndex = 1;
 
-    component.onWheelScroll({ deltaY: -1 } as WheelEvent); // Simula scroll up
+    component.onWheelScroll({ deltaY: -1, preventDefault: () => {} } as WheelEvent); // Simula scroll up
     expect(component.currentSectionIndex).toBe(0);
   });
 
@@ -67,7 +67,7 @@ describe('HomeComponent', () => {
     } as any;
     component.currentSectionIndex = 0;
 
-    component.onWheelScroll({ deltaY: -1 } as WheelEvent); // Simula scroll up
+    component.onWheelScroll({ deltaY: -1, preventDefault: () => {} } as WheelEvent); // Simula scroll up
     expect(component.currentSectionIndex).toBe(0); // Dovrebbe restare sulla prima sezione
   });
 
@@ -78,10 +78,10 @@ describe('HomeComponent', () => {
     component.currentSectionIndex = 0;
     component.isScrolling = false;
 
-    component.onWheelScroll({ deltaY: 1 } as WheelEvent); // Simula scroll down
+    component.onWheelScroll({ deltaY: 1, preventDefault: () => {} } as WheelEvent); // Simula scroll down
     expect(component.isScrolling).toBeTrue();
 
-    component.onWheelScroll({ deltaY: 1 } as WheelEvent); // Scroll bloccato
+    component.onWheelScroll({ deltaY: 1, preventDefault: () => {} } as WheelEvent); // Scroll bloccato
     expect(component.currentSectionIndex).toBe(1); // Indice resta invariato mentre isScrolling è true
   });
 });


### PR DESCRIPTION
## Summary
- update HomeComponent wheel scroll tests to provide a preventDefault stub when simulating wheel events

## Testing
- npm run test *(fails: ChromeHeadless cannot start due to missing system library libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a81d7f90832bbfe5fcd04ca37e46