### PR TITLE
Move landing mask initialization to OnInit

### DIFF
--- a/src/app/components/landing-mask/landing-mask.component.ts
+++ b/src/app/components/landing-mask/landing-mask.component.ts
@@ -8,7 +8,8 @@ import {
   HostListener,
   OnDestroy,
   PLATFORM_ID,
-  Inject
+  Inject,
+  OnInit
 } from '@angular/core';
 import { CommonModule, isPlatformBrowser } from '@angular/common';
 
@@ -38,7 +39,7 @@ interface PanelData {
   templateUrl: './landing-mask.component.html',
   styleUrls: ['./landing-mask.component.scss']
 })
-export class LandingMaskComponent implements AfterViewInit, OnDestroy {
+export class LandingMaskComponent implements OnInit, AfterViewInit, OnDestroy {
   initialAnimation = true;
   panels: PanelData[] = [];
 
@@ -57,11 +58,15 @@ export class LandingMaskComponent implements AfterViewInit, OnDestroy {
     this.isBrowser = isPlatformBrowser(this.platformId);
   }
 
-  ngAfterViewInit(): void {
+  ngOnInit(): void {
     if (!this.isBrowser) return;
 
     this.generatePanels();
     this.rotationAngles = new Array(this.panels.length).fill(0);
+  }
+
+  ngAfterViewInit(): void {
+    if (!this.isBrowser) return;
 
     setTimeout(() => {
       this.initialAnimation = false;


### PR DESCRIPTION
## Summary
- move the landing mask panel generation into `ngOnInit` so initialization happens before the first view check when running in the browser
- keep `ngAfterViewInit` focused on starting animations without reassigning the panel list

## Testing
- npm run test -- --watch=false --browsers=ChromeHeadless --include src/app/components/hero/hero.component.spec.ts *(fails: ChromeHeadless missing libatk-1.0.so.0 in container)*
- npm run test -- --watch=false --browsers=ChromeHeadless --include src/app/pages/home/home.component.spec.ts *(fails: ChromeHeadless missing libatk-1.0.so.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a82bbaf8832bac6fb14fc9dbb716