### PR TITLE
Guard skill popup target resolution

### DIFF
--- a/src/app/components/skills/skills.component.spec.ts
+++ b/src/app/components/skills/skills.component.spec.ts
@@ -78,9 +78,25 @@ describe('SkillsComponent', () => {
 
   it('should show popup message when a skill is clicked', () => {
     const skill = component.sections[0].skills[0];
-    const event = new MouseEvent('click');
-    spyOn(document, 'createElement').and.returnValue(document.createElement('div'));
+    const parentElement = document.createElement('div');
+    const targetElement = document.createElement('button');
+    parentElement.appendChild(targetElement);
+    const event = { currentTarget: targetElement } as unknown as MouseEvent;
+    const popupSpy = spyOn(component, 'createPopupMessage').and.callThrough();
+
     component.onSkillClick(event, skill);
-    expect(document.createElement).toHaveBeenCalledWith('div');
+
+    expect(popupSpy).toHaveBeenCalledWith(targetElement);
+    expect(parentElement.querySelector('.popup')).toBeTruthy();
+  });
+
+  it('should guard against missing event targets when creating popup', () => {
+    const skill = component.sections[0].skills[0];
+    const event = { currentTarget: null, target: null } as unknown as MouseEvent;
+    const popupSpy = spyOn(component, 'createPopupMessage');
+
+    component.onSkillClick(event, skill);
+
+    expect(popupSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/app/components/skills/skills.component.ts
+++ b/src/app/components/skills/skills.component.ts
@@ -66,13 +66,24 @@ export class SkillsComponent implements OnInit {
 
     skill.clicked = !skill.clicked;
 
-    if (skill.clicked) {
-      const message = this.createPopupMessage(event.target as HTMLElement);
+    if (!skill.clicked) {
+      return;
+    }
+
+    const resolvedTarget = (event.currentTarget ?? event.target);
+
+    if (!(resolvedTarget instanceof HTMLElement)) {
+      console.warn('Skill click target is not an HTMLElement.');
+      return;
+    }
+
+    const message = this.createPopupMessage(resolvedTarget);
+    if (message) {
       setTimeout(() => message.remove(), 5000);
     }
   }
 
-  createPopupMessage(targetElement: HTMLElement): HTMLElement {
+  createPopupMessage(targetElement: HTMLElement): HTMLElement | null {
     const message = document.createElement('div');
     message.classList.add('popup');
     message.style.cssText = `
@@ -87,7 +98,15 @@ export class SkillsComponent implements OnInit {
       padding: 10px;
       border-radius: 10px;
     `;
-    targetElement.parentElement?.appendChild(message);
+
+    const parent = targetElement.parentElement;
+
+    if (!parent) {
+      console.warn('Unable to attach popup message: parent element not found.');
+      return null;
+    }
+
+    parent.appendChild(message);
     return message;
   }
 }


### PR DESCRIPTION
## Summary
- guard skill click handling by preferring event.currentTarget and validating the element before showing a popup
- update popup creation to warn and skip when the target has no parent container
- extend the skills component spec to cover valid targets and null targets for the popup logic

## Testing
- CI=1 npm test -- --watch=false --browsers=ChromeHeadless *(fails: ChromeHeadless cannot start because libatk-1.0.so.0 is missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a8313c90832b8e268af4bf89ff43