### PR TITLE
Remove navigator debug logs

### DIFF
--- a/src/app/components/navigator/navigator.component.ts
+++ b/src/app/components/navigator/navigator.component.ts
@@ -76,18 +76,15 @@ export class NavigatorComponent implements OnInit {
       this.currentTheme = storedTheme;
       this.applyTheme(storedTheme);
     }
-    console.log('currentSectionIndex ngOnInit', this.currentSectionIndex)
   }
 
   onNext(): void {
-    console.log('currentSectionIndex onNext', this.currentSectionIndex)
     if (this.currentSectionIndex < this.totalSections - 1) {
       this.navigateNext.emit();
     }
   }
 
   onPrevious(): void {
-    console.log('currentSectionIndex onPrevious', this.currentSectionIndex)
     if (this.currentSectionIndex > 0) {
       this.navigatePrevious.emit();
     }


### PR DESCRIPTION
## Summary
- remove the console debug statements from the navigator component to avoid noisy test output

## Testing
- npm run test -- --watch=false *(fails: ChromeHeadless missing libatk-1.0.so.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2aa81d494832ba9ab82c4ca794f97