### PR TITLE
Add central hero accent square

### DIFF
--- a/src/app/components/hero/hero.component.html
+++ b/src/app/components/hero/hero.component.html
@@ -1,5 +1,6 @@
 <app-landing-mask></app-landing-mask>
 <div class="bg-container">
+  <div class="hero-square" aria-hidden="true"></div>
   <div class="hero-content">
     <h1>{{ displayText }}<span class="cursor">|</span></h1>
     <app-social></app-social>

--- a/src/app/components/hero/hero.component.scss
+++ b/src/app/components/hero/hero.component.scss
@@ -4,6 +4,7 @@
 }
 
 .bg-container {
+  position: relative;
   padding: 0;
   display: flex;
   flex-direction: column;
@@ -12,7 +13,18 @@
   height: 100vh;
   text-align: center;
 
-  
+  .hero-square {
+    position: absolute;
+    width: min(25vw, 220px);
+    height: min(25vw, 220px);
+    background: linear-gradient(135deg, #ffd600 0 50%, #000 50% 100%);
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 1;
+    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.25);
+  }
+
   .bottom-border {
     width: 100vw;
     height: 7px;


### PR DESCRIPTION
## Summary
- add a decorative yellow and black square to the hero section
- style the hero container to position the new accent behind the content

## Testing
- npm start -- --host 0.0.0.0 --port 4200


------
https://chatgpt.com/codex/tasks/task_e_68e2acf32cc8832bb91ce4590217374a