### PR TITLE
Replace email-validator dependency with native regex validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "@types/three": "^0.177.0",
         "angular-cli-ghpages": "^2.0.3",
         "dotenv-webpack": "^8.1.0",
-        "email-validator": "^2.0.4",
         "emailjs-com": "^3.2.0",
         "jasmine-core": "~5.2.0",
         "karma": "~6.4.0",
@@ -7639,15 +7638,6 @@
       "integrity": "sha512-k0/r7GrWVL32kZlGwfPNgB2Y/mMXVTq/decgLczm/j34whdaspNrZO8CnXPf1laaHxI6ptUlsnAxN+UAPw+fzg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/email-validator": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/email-validator/-/email-validator-2.0.4.tgz",
-      "integrity": "sha512-gYCwo7kh5S3IDyZPLZf6hSS0MnZT8QmJFqYvbqlDZSbwdZlY6QZWxJ4i/6UhITOJ4XzyI647Bm2MXKCLqnJ4nQ==",
-      "dev": true,
-      "engines": {
-        "node": ">4.0"
-      }
     },
     "node_modules/emailjs-com": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@types/three": "^0.177.0",
     "angular-cli-ghpages": "^2.0.3",
     "dotenv-webpack": "^8.1.0",
-    "email-validator": "^2.0.4",
     "emailjs-com": "^3.2.0",
     "jasmine-core": "~5.2.0",
     "karma": "~6.4.0",

--- a/src/app/services/email.service.spec.ts
+++ b/src/app/services/email.service.spec.ts
@@ -23,7 +23,7 @@ describe('EmailService', () => {
       expect(service.isValidEmail('invalid-email')).toBeFalse();
     });
 
-    it('should return false for an email with an invalid domain', () => {
+    it('should return false for an email missing a valid top-level domain', () => {
       expect(service.isValidEmail('test@invalid_domain')).toBeFalse();
     });
   });

--- a/src/app/services/email.service.ts
+++ b/src/app/services/email.service.ts
@@ -1,6 +1,5 @@
 // src/services/email.service.ts
 import { Injectable } from '@angular/core';
-import * as emailValidator from 'email-validator';
 
 /**
  * Service responsible for handling email-related operations.
@@ -15,24 +14,19 @@ export class EmailService {
   constructor() {}
 
   /**
-   * Validates the email format using a regular expression or email-validator library.
+   * Angular-aligned email validation regex (mirrors Validators.email behaviour).
+   * See https://angular.io/api/forms/Validators#email for reference.
+   */
+  private readonly emailPattern =
+    /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$/;
+
+  /**
+   * Validates the email format using a regular expression compatible with Angular's Validators.email.
    * @param email The email to validate.
    * @returns boolean Whether the email is valid.
    */
   isValidEmail(email: string): boolean {
-    // First validate the general email format
-    const isValidFormat = emailValidator.validate(email);
-
-    if (!isValidFormat) {
-      return false; // Invalid format
-    }
-
-    // Check if the domain exists (additional logic can be added to check for specific domains)
-    const domain = email.split('@')[1];
-    const domainPattern = /^[a-zA-Z0-9.-]+\.[a-zA-Z]{2,6}$/;
-    const isValidDomain = domainPattern.test(domain);
-
-    return isValidDomain;
+    return this.emailPattern.test(email);
   }
 
   /**


### PR DESCRIPTION
## Summary
- replace the email service validation with an Angular-compatible regular expression
- adjust the unit test expectations to reflect the regex-based validation
- drop the email-validator package from the project dependencies

## Testing
- npm run build *(fails: Inlining of fonts failed. https://fonts.googleapis.com/css2?family=Roboto returned status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e2aed1a94c832ba491d1dc388bdeee