### PR TITLE
chore: enforce secure http-proxy-middleware version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3,6 +3,9 @@
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
+  "overrides": {
+    "http-proxy-middleware": "^3.0.4"
+  },
   "packages": {
     "": {
       "name": "portfolio",
@@ -50,7 +53,8 @@
         "puppeteer": "^23.7.0",
         "sass": "^1.80.7",
         "three": "^0.177.0",
-        "typescript": "~5.5.2"
+        "typescript": "~5.5.2",
+        "http-proxy-middleware": "^3.0.4"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,10 @@
     "puppeteer": "^23.7.0",
     "sass": "^1.80.7",
     "three": "^0.177.0",
-    "typescript": "~5.5.2"
+    "typescript": "~5.5.2",
+    "http-proxy-middleware": "^3.0.4"
+  },
+  "overrides": {
+    "http-proxy-middleware": "^3.0.4"
   }
 }


### PR DESCRIPTION
## Summary
- add http-proxy-middleware@^3.0.4 to devDependencies and enforce it via overrides
- update the lockfile metadata so the override is captured

## Testing
- npm install *(fails: 403 Forbidden downloading http-proxy-middleware through the proxy)*
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68e2b05a6308832b9afe8081b366db01