### PR TITLE
chore: override nanoid to secure release

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,5 +55,8 @@
     "sass": "^1.80.7",
     "three": "^0.177.0",
     "typescript": "~5.5.2"
+  },
+  "overrides": {
+    "nanoid": "^3.3.8"
   }
 }


### PR DESCRIPTION
## Summary
- add an npm override to force nanoid to a patched release per the security advisory

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68e2b05a17ac832bb5624b5a373223b3