### PR TITLE
chore: pin webpack dev server to patched version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,11 @@
         "puppeteer": "^23.7.0",
         "sass": "^1.80.7",
         "three": "^0.177.0",
-        "typescript": "~5.5.2"
+        "typescript": "~5.5.2",
+        "webpack-dev-server": "^5.1.0"
+      },
+      "overrides": {
+        "webpack-dev-server": "^5.1.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -200,7 +204,7 @@
         "watchpack": "2.4.1",
         "webpack": "5.94.0",
         "webpack-dev-middleware": "7.4.2",
-        "webpack-dev-server": "5.0.4",
+        "webpack-dev-server": "5.1.0",
         "webpack-merge": "6.0.1",
         "webpack-subresource-integrity": "5.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -54,6 +54,10 @@
     "puppeteer": "^23.7.0",
     "sass": "^1.80.7",
     "three": "^0.177.0",
-    "typescript": "~5.5.2"
+    "typescript": "~5.5.2",
+    "webpack-dev-server": "^5.1.0"
+  },
+  "overrides": {
+    "webpack-dev-server": "^5.1.0"
   }
 }


### PR DESCRIPTION
## Summary
- add a direct devDependency on webpack-dev-server 5.1.0 and enforce it via npm overrides
- update the lockfile metadata so downstream installs resolve the patched dev server release

## Testing
- npm start -- --ssl true --host 0.0.0.0

------
https://chatgpt.com/codex/tasks/task_e_68e2b06d0368832ba220cbb0e1a09297