### PR TITLE
chore: vendor patched on-headers dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6914,6 +6914,9 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/compression/vendor/on-headers": {
+      "dev": true
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -11738,14 +11741,8 @@
       }
     },
     "node_modules/on-headers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
+      "resolved": "node_modules/compression/vendor/on-headers",
+      "link": true
     },
     "node_modules/once": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -55,5 +55,8 @@
     "sass": "^1.80.7",
     "three": "^0.177.0",
     "typescript": "~5.5.2"
+  },
+  "overrides": {
+    "on-headers": "file:vendor/on-headers"
   }
 }

--- a/tools/verify-on-headers.mjs
+++ b/tools/verify-on-headers.mjs
@@ -1,0 +1,71 @@
+import express from 'express'
+import http from 'node:http'
+import { createRequire } from 'node:module'
+import onHeaders from 'on-headers'
+
+const require = createRequire(import.meta.url)
+const { version: onHeadersVersion } = require('on-headers/package.json')
+
+function createApp () {
+  const app = express()
+
+  app.use((req, res, next) => {
+    onHeaders(res, () => {
+      res.setHeader('X-Patched-On-Headers', onHeadersVersion)
+    })
+
+    next()
+  })
+
+  app.get('/health', (req, res) => {
+    res.status(200).json({ status: 'ok' })
+  })
+
+  return app
+}
+
+function runCheck () {
+  const app = createApp()
+  const server = app.listen(0, () => {
+    const { port } = server.address()
+
+    const request = http.get({ port, path: '/health' }, (res) => {
+      const headerValue = res.headers['x-patched-on-headers']
+
+      let body = ''
+      res.setEncoding('utf8')
+      res.on('data', (chunk) => {
+        body += chunk
+      })
+
+      res.on('end', () => {
+        server.close(() => {
+          const isHeaderValid = headerValue === onHeadersVersion
+          const isBodyValid = body.includes('"status":"ok"')
+
+          if (!isHeaderValid || !isBodyValid) {
+            console.error('Header verification failed', { headerValue, body })
+            process.exitCode = 1
+            return
+          }
+
+          console.log('Header verification succeeded', { headerValue })
+        })
+      })
+    })
+
+    request.on('error', (error) => {
+      server.close(() => {
+        console.error('HTTP request failed', error)
+        process.exitCode = 1
+      })
+    })
+  })
+
+  server.on('error', (error) => {
+    console.error('Server failed to start', error)
+    process.exitCode = 1
+  })
+}
+
+runCheck()

--- a/vendor/on-headers/index.js
+++ b/vendor/on-headers/index.js
@@ -1,0 +1,94 @@
+'use strict'
+
+module.exports = onHeaders
+
+function createWriteHead (prevWriteHead, listener) {
+  var fired = false
+
+  return function writeHead (statusCode) {
+    var args = setWriteHeadHeaders.apply(this, arguments)
+
+    if (!fired) {
+      fired = true
+      listener.call(this)
+
+      if (typeof args[0] === 'number' && this.statusCode !== args[0]) {
+        args[0] = this.statusCode
+        args.length = 1
+      }
+    }
+
+    return prevWriteHead.apply(this, args)
+  }
+}
+
+function onHeaders (res, listener) {
+  if (!res) {
+    throw new TypeError('argument res is required')
+  }
+
+  if (typeof listener !== 'function') {
+    throw new TypeError('argument listener must be a function')
+  }
+
+  res.writeHead = createWriteHead(res.writeHead, listener)
+}
+
+function isSafeHeaderName (name) {
+  return typeof name === 'string' && name.length > 0 && name !== '__proto__' && name !== 'constructor'
+}
+
+function setHeadersFromArray (res, headers) {
+  for (var i = 0; i < headers.length; i++) {
+    var header = headers[i]
+    if (!Array.isArray(header) || header.length < 2) {
+      continue
+    }
+
+    var key = header[0]
+    if (!isSafeHeaderName(key)) {
+      continue
+    }
+
+    res.setHeader(String(key), header[1])
+  }
+}
+
+function setHeadersFromObject (res, headers) {
+  var keys = Object.keys(headers)
+  for (var i = 0; i < keys.length; i++) {
+    var k = keys[i]
+
+    if (!isSafeHeaderName(k)) {
+      continue
+    }
+
+    res.setHeader(k, headers[k])
+  }
+}
+
+function setWriteHeadHeaders (statusCode) {
+  var length = arguments.length
+  var headerIndex = length > 1 && typeof arguments[1] === 'string'
+    ? 2
+    : 1
+
+  var headers = length >= headerIndex + 1
+    ? arguments[headerIndex]
+    : undefined
+
+  this.statusCode = statusCode
+
+  if (Array.isArray(headers)) {
+    setHeadersFromArray(this, headers)
+  } else if (headers && typeof headers === 'object') {
+    setHeadersFromObject(this, headers)
+  }
+
+  var args = new Array(Math.min(length, headerIndex))
+  for (var i = 0; i < args.length; i++) {
+    args[i] = arguments[i]
+  }
+
+  return args
+}

--- a/vendor/on-headers/package.json
+++ b/vendor/on-headers/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "on-headers",
+  "version": "1.0.3",
+  "description": "Execute a listener when a response is about to write headers (patched)",
+  "main": "index.js",
+  "license": "MIT"
+}


### PR DESCRIPTION
## Summary
- override on-headers to a vendored 1.0.3 build that guards against unsafe header names
- add a repeatable verification script to confirm Express responses include the patched header

## Testing
- node tools/verify-on-headers.mjs

------
https://chatgpt.com/codex/tasks/task_e_68e2b05e8a8c832ba2d8aafeee95c1a4