### PR TITLE
chore: enforce patched gh-pages release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,9 @@
         "sass": "^1.80.7",
         "three": "^0.177.0",
         "typescript": "~5.5.2"
+      },
+      "overrides": {
+        "gh-pages": "^6.1.1"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -55,5 +55,8 @@
     "sass": "^1.80.7",
     "three": "^0.177.0",
     "typescript": "~5.5.2"
+  },
+  "overrides": {
+    "gh-pages": "^6.1.1"
   }
 }


### PR DESCRIPTION
## Summary
- add an npm overrides entry to force gh-pages to resolve to version 6.1.1 or newer
- mirror the override inside the lockfile so the workspace metadata reflects the enforced version

## Testing
- `npm install` *(fails: registry returned 403 when fetching gh-pages)*
- `npx angular-cli-ghpages --dir=tmp/deploy --dry-run --repo https://github.com/example/repo.git --branch test-branch --message "Test deployment"`


------
https://chatgpt.com/codex/tasks/task_e_68e2b0594974832ba9a40ead913cb875