### PR TITLE
refactor: lazy load home sections and replace Material components

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -37,7 +37,6 @@
               }
             ],
             "styles": [
-              "@angular/material/prebuilt-themes/azure-blue.css",
               "src/styles/styles.scss"
             ],
             "scripts": [],
@@ -63,7 +62,12 @@
                 }
               ],
               "outputHashing": "all",
-              "baseHref": "/portfolio/"
+              "baseHref": "/portfolio/",
+              "optimization": {
+                "fonts": {
+                  "inline": false
+                }
+              }
             },
             "development": {
               "optimization": false,
@@ -105,7 +109,6 @@
               }
             ],
             "styles": [
-              "@angular/material/prebuilt-themes/azure-blue.css",
               "src/styles/styles.scss"
             ],
             "scripts": []

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,10 @@
       "version": "0.0.0",
       "dependencies": {
         "@angular/animations": "^18.2.0",
-        "@angular/cdk": "^18.2.12",
         "@angular/common": "^18.2.0",
         "@angular/compiler": "^18.2.0",
         "@angular/core": "^18.2.0",
         "@angular/forms": "^18.2.0",
-        "@angular/material": "^18.2.12",
         "@angular/platform-browser": "^18.2.0",
         "@angular/platform-browser-dynamic": "^18.2.0",
         "@angular/platform-server": "^18.2.0",
@@ -471,23 +469,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@angular/cdk": {
-      "version": "18.2.12",
-      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-18.2.12.tgz",
-      "integrity": "sha512-FOklA6KatPtb0yO0doRhBI/UVY23A8ZhOSws5VuZTQl/6r/jXEXGV9n5JQj4rm8t/6IrReO55hdyw9XfHfZFjQ==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "optionalDependencies": {
-        "parse5": "^7.1.2"
-      },
-      "peerDependencies": {
-        "@angular/common": "^18.0.0 || ^19.0.0",
-        "@angular/core": "^18.0.0 || ^19.0.0",
-        "rxjs": "^6.5.3 || ^7.4.0"
-      }
-    },
     "node_modules/@angular/cli": {
       "version": "18.2.10",
       "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-18.2.10.tgz",
@@ -648,24 +629,6 @@
         "@angular/common": "18.2.9",
         "@angular/core": "18.2.9",
         "@angular/platform-browser": "18.2.9",
-        "rxjs": "^6.5.3 || ^7.4.0"
-      }
-    },
-    "node_modules/@angular/material": {
-      "version": "18.2.12",
-      "resolved": "https://registry.npmjs.org/@angular/material/-/material-18.2.12.tgz",
-      "integrity": "sha512-5q8Os6i3D1e3qN+RqP95UgIR+Kx3goncSSYDeT6yPNrdrcqcWdyDPXGK6UsZqTTx/CJee/I7ZxgVVK1YDoVASQ==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "@angular/animations": "^18.0.0 || ^19.0.0",
-        "@angular/cdk": "18.2.12",
-        "@angular/common": "^18.0.0 || ^19.0.0",
-        "@angular/core": "^18.0.0 || ^19.0.0",
-        "@angular/forms": "^18.0.0 || ^19.0.0",
-        "@angular/platform-browser": "^18.0.0 || ^19.0.0",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
@@ -12109,7 +12072,7 @@
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
       "integrity": "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^4.5.0"

--- a/package.json
+++ b/package.json
@@ -13,12 +13,10 @@
   "private": true,
   "dependencies": {
     "@angular/animations": "^18.2.0",
-    "@angular/cdk": "^18.2.12",
     "@angular/common": "^18.2.0",
     "@angular/compiler": "^18.2.0",
     "@angular/core": "^18.2.0",
     "@angular/forms": "^18.2.0",
-    "@angular/material": "^18.2.12",
     "@angular/platform-browser": "^18.2.0",
     "@angular/platform-browser-dynamic": "^18.2.0",
     "@angular/platform-server": "^18.2.0",

--- a/src/app/components/contact-me/contact-me.component.html
+++ b/src/app/components/contact-me/contact-me.component.html
@@ -7,32 +7,36 @@
   </div>
 
   <form #contactForm="ngForm" (ngSubmit)="onSubmit(contactForm.value)" class="contact-form">
-    <mat-form-field appearance="fill" class="form-field">
-      <mat-label>{{ contactMe.name }}</mat-label>
-      <input matInput type="text" id="name" name="name" ngModel required>
-      <mat-error *ngIf="contactForm.submitted && !contactForm.form.controls['name']?.valid">
+    <div class="form-field">
+      <label class="field-label" for="name">{{ contactMe.name }}</label>
+      <input class="field-control" type="text" id="name" name="name" ngModel #nameModel="ngModel" required
+        [attr.aria-invalid]="contactForm.submitted && nameModel.invalid ? 'true' : null" />
+      <p class="field-error" *ngIf="contactForm.submitted && nameModel.invalid">
         {{ contactMe.nameReq }}
-      </mat-error>
-    </mat-form-field>
+      </p>
+    </div>
 
-    <mat-form-field appearance="fill" class="form-field">
-      <mat-label>{{ contactMe.email }}</mat-label>
-      <input matInput type="email" id="email" name="email" ngModel required email>
-      <mat-error *ngIf="contactForm.submitted && !contactForm.form.controls['email']?.valid">
+    <div class="form-field">
+      <label class="field-label" for="email">{{ contactMe.email }}</label>
+      <input class="field-control" type="email" id="email" name="email" ngModel #emailModel="ngModel" required email
+        [attr.aria-invalid]="contactForm.submitted && emailModel.invalid ? 'true' : null" />
+      <p class="field-error" *ngIf="contactForm.submitted && emailModel.invalid">
         {{ contactMe.emailReq }}
-      </mat-error>
-    </mat-form-field>
+      </p>
+    </div>
 
-    <mat-form-field appearance="fill" class="form-field">
-      <mat-label>{{ contactMe.message }}</mat-label>
-      <textarea matInput id="message" name="message" ngModel required></textarea>
-      <mat-error *ngIf="contactForm.submitted && !contactForm.form.controls['message']?.valid">
+    <div class="form-field">
+      <label class="field-label" for="message">{{ contactMe.message }}</label>
+      <textarea class="field-control field-control--textarea" id="message" name="message" ngModel
+        #messageModel="ngModel" required rows="5"
+        [attr.aria-invalid]="contactForm.submitted && messageModel.invalid ? 'true' : null"></textarea>
+      <p class="field-error" *ngIf="contactForm.submitted && messageModel.invalid">
         {{ contactMe.messageReq }}
-      </mat-error>
-    </mat-form-field>
+      </p>
+    </div>
 
     <div class="submit-btn">
-      <button mat-raised-button type="submit" [disabled]="!contactForm.form.valid"
+      <button type="submit" class="submit-button" [disabled]="!contactForm.form.valid"
         [ngClass]="{ 'enabled': contactForm.form.valid, 'disabled': !contactForm.form.valid }">
         {{ contactMe.sendBtn }}
       </button>

--- a/src/app/components/contact-me/contact-me.component.scss
+++ b/src/app/components/contact-me/contact-me.component.scss
@@ -27,24 +27,81 @@
         width: 90vw;
         max-width: 600px;
         margin-bottom: 1rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
 
-        .mdc-text-field {
-            position: static;
+        .field-label {
+            font-weight: 600;
+            font-size: 1rem;
         }
 
-        .mat-mdc-text-field-wrapper {
-            width: 96% !important;
+        .field-control {
+            width: 100%;
+            padding: 0.75rem 1rem;
+            border-radius: 0.75rem;
+            border: 1px solid rgba(0, 0, 0, 0.15);
+            background-color: rgba(255, 255, 255, 0.85);
+            color: inherit;
+            font-size: 1rem;
+            transition: border-color 0.2s ease, box-shadow 0.2s ease;
+
+            &:focus {
+                outline: none;
+                border-color: rgba(0, 0, 0, 0.4);
+                box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.08);
+            }
+
+            &[aria-invalid='true'] {
+                border-color: #f87171;
+                box-shadow: 0 0 0 3px rgba(248, 113, 113, 0.25);
+            }
         }
 
-        .mat-form-field {
-            width: 96% !important;
+        .field-control--textarea {
+            resize: vertical;
+            min-height: 140px;
+        }
+
+        .field-error {
+            color: #f87171;
+            font-size: 0.875rem;
+            margin: 0;
         }
     }
 
     .submit-btn {
         display: flex;
         justify-content: center;
-        margin-top: 1rem;
+        margin-top: 1.5rem;
+
+        .submit-button {
+            border: none;
+            border-radius: 9999px;
+            padding: 0.85rem 2.5rem;
+            font-size: 1rem;
+            font-weight: 600;
+            cursor: pointer;
+            transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+            background: linear-gradient(135deg, #1e3c72, #2a5298);
+            color: #fff;
+
+            &.disabled,
+            &:disabled {
+                cursor: not-allowed;
+                opacity: 0.6;
+                box-shadow: none;
+            }
+
+            &.enabled {
+                box-shadow: 0 10px 25px rgba(30, 60, 114, 0.35);
+
+                &:hover {
+                    transform: translateY(-2px);
+                    box-shadow: 0 14px 30px rgba(30, 60, 114, 0.45);
+                }
+            }
+        }
     }
 }
 

--- a/src/app/components/contact-me/contact-me.component.ts
+++ b/src/app/components/contact-me/contact-me.component.ts
@@ -4,9 +4,6 @@ import { CustomPopupComponent } from '../custom-popup/custom-popup.component';
 import { contactMeData } from '../../data/contact-me.data';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { MatInputModule } from '@angular/material/input';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatButtonModule } from '@angular/material/button';
 import { ContactMe } from '../../dtos/ContactMeDTO';
 import { EmailService } from '../../services/email.service';
 import { TranslationService } from '../../services/translation.service';
@@ -19,9 +16,6 @@ import { TranslationService } from '../../services/translation.service';
     CustomPopupComponent,
     CommonModule,
     FormsModule,
-    MatInputModule,
-    MatFormFieldModule,
-    MatButtonModule,
   ],
   encapsulation: ViewEncapsulation.None,
   templateUrl: './contact-me.component.html',

--- a/src/app/components/navigator/navigator.component.html
+++ b/src/app/components/navigator/navigator.component.html
@@ -1,52 +1,52 @@
 <!-- Floating toggle button -->
 <button class="nav-toggle-button" *ngIf="!isOpen" (click)="toggleNavigator()" aria-label="Open navigator">
-  <mat-icon>chevron_left</mat-icon>
+  <span class="material-symbols-outlined" aria-hidden="true">chevron_left</span>
 </button>
 
 <!-- Modern, animated, circular floating navbar -->
 <div class="modern-navigator" *ngIf="isOpen">
   <div class="arrow-container">
     <!-- Previous button -->
-    <button class="arrow-button" *ngIf="currentSectionIndex > 0" (click)="onPrevious()" aria-label="Previous section"
-      [matTooltip]="getTooltip('prev')" matTooltipPosition="left">
-      <mat-icon>arrow_upward</mat-icon>
+    <button class="arrow-button" *ngIf="currentSectionIndex > 0" (click)="onPrevious()"
+      [attr.aria-label]="getTooltip('prev')" [attr.title]="getTooltip('prev')">
+      <span class="material-symbols-outlined" aria-hidden="true">arrow_upward</span>
     </button>
 
     <!-- Next button -->
-    <button class="arrow-button" *ngIf="currentSectionIndex < totalSections - 1" (click)="onNext()" aria-label="Next section"
-      [matTooltip]="getTooltip('next')" matTooltipPosition="left">
-      <mat-icon>arrow_downward</mat-icon>
+    <button class="arrow-button" *ngIf="currentSectionIndex < totalSections - 1" (click)="onNext()"
+      [attr.aria-label]="getTooltip('next')" [attr.title]="getTooltip('next')">
+      <span class="material-symbols-outlined" aria-hidden="true">arrow_downward</span>
     </button>
   </div>
 
   <div class="nav-group">
-    <button class="nav-button" (click)="toggleThemeOptions()" aria-label="Theme selector"
-      [matTooltip]="getTooltip('theme')" matTooltipPosition="left">
-      <mat-icon>{{ getThemeIcon(currentTheme) }}</mat-icon>
+    <button class="nav-button" (click)="toggleThemeOptions()" [attr.aria-label]="getTooltip('theme')"
+      [attr.title]="getTooltip('theme')">
+      <span class="material-symbols-outlined" aria-hidden="true">{{ getThemeIcon(currentTheme) }}</span>
     </button>
     <div class="option-container" *ngIf="showThemeOptions">
       <button class="option-button" (click)="changeTheme('light')" aria-label="Light mode"
         [class.selected]="currentTheme === 'light'">
-        <mat-icon>light_mode</mat-icon>
+        <span class="material-symbols-outlined" aria-hidden="true">light_mode</span>
       </button>
       <button class="option-button" (click)="changeTheme('dark')" aria-label="Dark mode"
         [class.selected]="currentTheme === 'dark'">
-        <mat-icon>dark_mode</mat-icon>
+        <span class="material-symbols-outlined" aria-hidden="true">dark_mode</span>
       </button>
       <button class="option-button" (click)="changeTheme('blue')" aria-label="Blue mode"
         [class.selected]="currentTheme === 'blue'">
-        <mat-icon>water_drop</mat-icon>
+        <span class="material-symbols-outlined" aria-hidden="true">water_drop</span>
       </button>
       <button class="option-button" (click)="changeTheme('green')" aria-label="Green mode"
         [class.selected]="currentTheme === 'green'">
-        <mat-icon>eco</mat-icon>
+        <span class="material-symbols-outlined" aria-hidden="true">eco</span>
       </button>
     </div>
   </div>
 
   <div class="nav-group">
-    <button class="nav-button" (click)="toggleLanguageOptions()" [matTooltip]="getTooltip('language')"
-      matTooltipPosition="left">
+    <button class="nav-button" (click)="toggleLanguageOptions()" [attr.title]="getTooltip('language')"
+      [attr.aria-label]="getTooltip('language')">
       <span class="lang-label">{{ currentLang | slice:0:3 | uppercase }}</span>
     </button>
     <div class="option-container" *ngIf="showLanguageOptions">

--- a/src/app/components/navigator/navigator.component.scss
+++ b/src/app/components/navigator/navigator.component.scss
@@ -6,6 +6,10 @@ $navigator-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
 $navigator-icon-size: 24px;
 $navigator-button-size: 48px;
 
+.material-symbols-outlined {
+    font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+}
+
 @keyframes float {
 
     0%,
@@ -31,14 +35,13 @@ $navigator-button-size: 48px;
     display: flex;
     align-items: center;
     justify-content: center;
+    color: #333;
     animation: float 3s ease-in-out infinite;
     cursor: pointer;
     z-index: 9999;
 
-    mat-icon {
-        position: absolute;
+    .material-symbols-outlined {
         font-size: $navigator-icon-size;
-        color: #333;
     }
 
     &:hover {
@@ -81,6 +84,7 @@ $navigator-button-size: 48px;
         flex-direction: column;
         align-items: center;
         justify-content: center;
+        color: #333;
         transition: transform 0.2s ease, background-color 0.3s ease;
 
         &:hover {
@@ -88,9 +92,8 @@ $navigator-button-size: 48px;
             background-color: lighten($navigator-bg, 4%);
         }
 
-        mat-icon {
+        .material-symbols-outlined {
             font-size: $navigator-icon-size;
-            color: #333;
         }
 
         .lang-label {
@@ -109,98 +112,16 @@ $navigator-button-size: 48px;
         display: flex;
         align-items: center;
         justify-content: center;
+        color: #333;
+        font-size: $navigator-icon-size;
         transition: background-color 0.2s ease;
 
         &:hover {
             background-color: rgba(0, 0, 0, 0.05);
         }
-
-        mat-icon {
-            font-size: $navigator-icon-size;
-            color: #333;
-            position: absolute;
-        }
     }
 }
 
-body.dark-mode {
-    .nav-toggle-button {
-        background-color: $navigator-bg-dark;
-
-        mat-icon {
-            color: #f0f0f0;
-        }
-
-        &:hover {
-            background-color: lighten($navigator-bg-dark, 5%);
-        }
-    }
-
-    .modern-navigator {
-
-        .nav-button,
-        .arrow-container {
-            background-color: $navigator-bg-dark;
-        }
-
-        .nav-button:hover,
-        .arrow-button:hover {
-            background-color: lighten($navigator-bg-dark, 5%);
-        }
-
-        .nav-button mat-icon,
-        .nav-button .lang-label,
-        .arrow-button mat-icon {
-            color: #f0f0f0;
-        }
-    }
-}
-
-body.blue-mode {
-    .nav-toggle-button {
-        background-color: $navigator-bg;
-
-        &:hover {
-            background-color: lighten($navigator-bg, 4%);
-        }
-    }
-
-    .modern-navigator {
-
-        .nav-button,
-        .arrow-container {
-            background-color: $navigator-bg;
-        }
-
-        .nav-button:hover,
-        .arrow-button:hover {
-            background-color: lighten($navigator-bg, 4%);
-        }
-    }
-}
-
-body.green-mode {
-    .nav-toggle-button {
-        background-color: $navigator-bg;
-
-        &:hover {
-            background-color: lighten($navigator-bg, 4%);
-        }
-    }
-
-    .modern-navigator {
-
-        .nav-button,
-        .arrow-container {
-            background-color: $navigator-bg;
-        }
-
-        .nav-button:hover,
-        .arrow-button:hover {
-            background-color: lighten($navigator-bg, 4%);
-        }
-    }
-}
 
 .lang-flag {
     font-size: 1.2rem;
@@ -226,17 +147,7 @@ body.green-mode {
     z-index: 1;
 }
 
-body.dark-mode {
-    .option-container {
-        background: $navigator-bg-dark;
-    }
 
-    .option-button mat-icon,
-    .option-button .lang-flag {
-        position: absolute;
-        color: #f0f0f0;
-    }
-}
 
 .option-button {
     width: 32px;
@@ -247,16 +158,12 @@ body.dark-mode {
     align-items: center;
     justify-content: center;
     background-color: transparent;
+    color: #333;
+    font-size: 20px;
     transition: background-color 0.2s ease;
 
     &:hover {
         background-color: rgba(0, 0, 0, 0.05);
-    }
-
-    mat-icon {
-        position: absolute;
-        font-size: 20px;
-        color: #333;
     }
 
     .section-number {
@@ -271,18 +178,3 @@ body.dark-mode {
     }
 }
 
-body.dark-mode {
-    .option-button:hover {
-        background-color: rgba(255, 255, 255, 0.1);
-    }
-
-    .option-button mat-icon,
-    .option-button .section-number {
-        position: absolute;
-        color: #f0f0f0;
-    }
-
-    .option-button.selected {
-        background-color: rgba(255, 255, 255, 0.2);
-    }
-}

--- a/src/app/components/navigator/navigator.component.spec.ts
+++ b/src/app/components/navigator/navigator.component.spec.ts
@@ -1,7 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NavigatorComponent } from './navigator.component';
-import { MatIconModule } from '@angular/material/icon';
-import { MatTooltipModule } from '@angular/material/tooltip';
 import { ThemeswitchComponent } from './themeswitch/themeswitch.component';
 
 /**
@@ -16,7 +14,7 @@ describe('NavigatorComponent', () => {
    */
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [NavigatorComponent, MatIconModule, MatTooltipModule, ThemeswitchComponent]
+      imports: [NavigatorComponent, ThemeswitchComponent]
     })
       .compileComponents();
 

--- a/src/app/components/navigator/navigator.component.ts
+++ b/src/app/components/navigator/navigator.component.ts
@@ -1,7 +1,5 @@
 import { Component, EventEmitter, Input, Output, OnInit, Inject, PLATFORM_ID, HostListener, ElementRef } from '@angular/core';
 import { CommonModule, isPlatformBrowser } from '@angular/common';
-import { MatIconModule } from '@angular/material/icon';
-import { MatTooltipModule } from '@angular/material/tooltip';
 import { TranslationService } from '../../services/translation.service';
 
 @Component({
@@ -9,8 +7,6 @@ import { TranslationService } from '../../services/translation.service';
   standalone: true,
   imports: [
     CommonModule,
-    MatIconModule,
-    MatTooltipModule,
   ],
   templateUrl: './navigator.component.html',
   styleUrls: ['./navigator.component.scss']

--- a/src/app/components/stats/stats.component.html
+++ b/src/app/components/stats/stats.component.html
@@ -6,7 +6,7 @@
         <div *ngFor="let stat of statistics" class="statistics-card">
           <div class="statistics-content">
             <div class="statistics-icon">
-              <mat-icon>{{ stat.icon }}</mat-icon>
+              <span class="material-symbols-outlined" aria-hidden="true">{{ stat.icon }}</span>
             </div>
             <p class="statistics-label">{{ stat.label }}</p>
             <h2 class="statistics-value">{{ stat.value }}</h2>

--- a/src/app/components/stats/stats.component.scss
+++ b/src/app/components/stats/stats.component.scss
@@ -8,13 +8,6 @@
     .statistics-section {
         position: relative;
 
-        .statistics-overlay {
-            position: absolute;
-            inset: 0;
-            width: 100%;
-            height: 100%;
-        }
-
         .statistics-container {
             max-width: 1320px;
             margin: 0 auto;
@@ -48,10 +41,14 @@
                 .statistics-icon {
                     margin-bottom: 15px;
 
-                    mat-icon {
+                    .material-symbols-outlined {
                         font-size: 7vh;
                         width: 100%;
                         height: 100%;
+                        font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 48;
+                        display: inline-flex;
+                        align-items: center;
+                        justify-content: center;
                     }
                 }
 
@@ -81,57 +78,4 @@
         }
     }
 
-    @media (max-width: 1200px) {
-        .statistics-card {
-            flex: 1 1 calc(33.33% - 20px);
-            max-width: 240px;
-            min-width: 220px;
-        }
-    }
-
-    @media (max-width: 992px) {
-        .statistics-component{
-            padding: 0 !important;
-        }
-
-        .statistics-card {
-            flex: 1 1 calc(50% - 20px);
-            max-width: 300px;
-            min-width: 200px;
-        }
-    }
-
-    @media (max-width: 768px) {
-        .statistics-component{
-            padding: 0 !important;
-        }
-
-        .statistics-card {
-            flex: 1 1 100% !important;
-            max-width: 280px !important;
-            min-width: 180px !important;
-            padding: 10px !important;
-        }
-
-        h2{
-            font-size: 1.5rem !important;
-        }
-    }
-
-    @media (max-width: 480px) {
-        .statistics-component{
-            padding: 0 !important;
-        }
-
-        .statistics-card {
-            flex: 1 1 100% !important;
-            max-width: 34vw !important;
-            min-width: 90px !important;
-            padding: 5px !important;
-        }
-
-        h2{
-            font-size: 1rem !important;
-        }
-    }
 }

--- a/src/app/components/stats/stats.component.ts
+++ b/src/app/components/stats/stats.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnInit } from '@angular/core';
-import { MatIconModule } from '@angular/material/icon';
 import { CommonModule } from '@angular/common';
 import { experiencesData } from '../../data/experiences.data';
 import { projects } from '../../data/projects.data';
@@ -11,7 +10,6 @@ import { statsData } from '../../data/stats.data';
   selector: 'app-stats',
   standalone: true,
   imports: [
-    MatIconModule,
     CommonModule
   ],
   templateUrl: './stats.component.html',

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -1,12 +1,60 @@
 <div *ngIf="viewInitialized">
   <div #section><app-hero (navigateNextSection)="navigateNext()"></app-hero></div>
   <div #section><app-about></app-about></div>
-  <div #section><app-projects></app-projects></div>
-  <div #section><app-skills></app-skills></div>
-  <div #section><app-education></app-education></div>
-  <div #section><app-experiences></app-experiences></div>
-  <div #section><app-stats></app-stats></div>
-  <div #section><app-contact-me></app-contact-me></div>
+  <div #section>
+    @defer (on viewport) {
+      @if (loadProjectsComponent() | async; as component) {
+        <ng-container *ngComponentOutlet="component"></ng-container>
+      }
+    } @placeholder {
+      <div class="section-placeholder" aria-hidden="true"></div>
+    }
+  </div>
+  <div #section>
+    @defer (on viewport) {
+      @if (loadSkillsComponent() | async; as component) {
+        <ng-container *ngComponentOutlet="component"></ng-container>
+      }
+    } @placeholder {
+      <div class="section-placeholder" aria-hidden="true"></div>
+    }
+  </div>
+  <div #section>
+    @defer (on viewport) {
+      @if (loadEducationComponent() | async; as component) {
+        <ng-container *ngComponentOutlet="component"></ng-container>
+      }
+    } @placeholder {
+      <div class="section-placeholder" aria-hidden="true"></div>
+    }
+  </div>
+  <div #section>
+    @defer (on viewport) {
+      @if (loadExperiencesComponent() | async; as component) {
+        <ng-container *ngComponentOutlet="component"></ng-container>
+      }
+    } @placeholder {
+      <div class="section-placeholder" aria-hidden="true"></div>
+    }
+  </div>
+  <div #section>
+    @defer (on viewport) {
+      @if (loadStatsComponent() | async; as component) {
+        <ng-container *ngComponentOutlet="component"></ng-container>
+      }
+    } @placeholder {
+      <div class="section-placeholder" aria-hidden="true"></div>
+    }
+  </div>
+  <div #section>
+    @defer (on viewport) {
+      @if (loadContactMeComponent() | async; as component) {
+        <ng-container *ngComponentOutlet="component"></ng-container>
+      }
+    } @placeholder {
+      <div class="section-placeholder" aria-hidden="true"></div>
+    }
+  </div>
 
   <app-navigator [totalSections]="totalSections" [currentSectionIndex]="currentSectionIndex"
     (navigateNext)="navigateNext()" (navigatePrevious)="navigatePrevious()">

--- a/src/app/pages/home/home.component.scss
+++ b/src/app/pages/home/home.component.scss
@@ -1,0 +1,22 @@
+@use '../../../styles/variables.scss' as *;
+
+.section-placeholder {
+  min-height: 50vh;
+  border-radius: 24px;
+  background: rgba(0, 0, 0, 0.06);
+  margin: 2rem auto;
+  max-width: 1100px;
+  width: 100%;
+  animation: pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 0.35;
+  }
+
+  50% {
+    opacity: 0.65;
+  }
+}

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -9,35 +9,36 @@ import {
   HostListener
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ProjectsComponent } from '../../components/projects/projects.component';
 import { AboutComponent } from '../../components/about/about.component';
 import { HeroComponent } from '../../components/hero/hero.component';
-import { SkillsComponent } from '../../components/skills/skills.component';
 import { NavigatorComponent } from '../../components/navigator/navigator.component';
-import { EducationComponent } from '../../components/education/education.component';
-import { StatsComponent } from '../../components/stats/stats.component';
-import { ContactMeComponent } from '../../components/contact-me/contact-me.component';
-import { ExperiencesComponent } from '../../components/experiences/experiences.component';
 
 @Component({
   selector: 'app-home',
   standalone: true,
   imports: [
     CommonModule,
-    ProjectsComponent,
     AboutComponent,
     HeroComponent,
-    SkillsComponent,
     NavigatorComponent,
-    EducationComponent,
-    StatsComponent,
-    ContactMeComponent,
-    ExperiencesComponent
   ],
   templateUrl: './home.component.html',
   styleUrls: ['./home.component.scss']
 })
 export class HomeComponent implements AfterViewInit, OnInit {
+  readonly loadProjectsComponent = () => import('../../components/projects/projects.component')
+    .then(m => m.ProjectsComponent);
+  readonly loadSkillsComponent = () => import('../../components/skills/skills.component')
+    .then(m => m.SkillsComponent);
+  readonly loadEducationComponent = () => import('../../components/education/education.component')
+    .then(m => m.EducationComponent);
+  readonly loadExperiencesComponent = () => import('../../components/experiences/experiences.component')
+    .then(m => m.ExperiencesComponent);
+  readonly loadStatsComponent = () => import('../../components/stats/stats.component')
+    .then(m => m.StatsComponent);
+  readonly loadContactMeComponent = () => import('../../components/contact-me/contact-me.component')
+    .then(m => m.ContactMeComponent);
+
   currentSectionIndex = 0;
   viewInitialized = false;
   totalSections = 0;

--- a/src/index.html
+++ b/src/index.html
@@ -17,7 +17,8 @@
   </script>
 
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <link rel="stylesheet"
+    href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0" />
 </head>
 
 <body>

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -86,3 +86,110 @@ mat-error {
         bottom: 60px !important;
     }
 }
+
+body.dark-mode {
+    .nav-toggle-button {
+        background-color: #1f1f1f;
+
+        .material-symbols-outlined {
+            color: #f0f0f0;
+        }
+
+        &:hover {
+            background-color: #2c2c2c;
+        }
+    }
+
+    .modern-navigator {
+        .nav-button,
+        .arrow-container {
+            background-color: #1f1f1f;
+        }
+
+        .nav-button:hover,
+        .arrow-button:hover {
+            background-color: #2c2c2c;
+        }
+
+        .nav-button .material-symbols-outlined,
+        .nav-button .lang-label,
+        .arrow-button .material-symbols-outlined {
+            color: #f0f0f0;
+        }
+    }
+
+    .option-container {
+        background: #1f1f1f;
+    }
+
+    .option-button {
+        color: #f0f0f0;
+    }
+
+    .option-button .lang-flag,
+    .option-button .section-number {
+        color: #f0f0f0;
+    }
+
+    .option-button:hover {
+        background-color: rgba(255, 255, 255, 0.1);
+    }
+
+    .option-button.selected {
+        background-color: rgba(255, 255, 255, 0.2);
+    }
+}
+
+@media (max-width: 1200px) {
+    .statistics-component .statistics-card {
+        flex: 1 1 calc(33.33% - 20px);
+        max-width: 240px;
+        min-width: 220px;
+    }
+}
+
+@media (max-width: 992px) {
+    .statistics-component {
+        padding: 0 !important;
+    }
+
+    .statistics-component .statistics-card {
+        flex: 1 1 calc(50% - 20px);
+        max-width: 300px;
+        min-width: 200px;
+    }
+}
+
+@media (max-width: 768px) {
+    .statistics-component {
+        padding: 0 !important;
+    }
+
+    .statistics-component .statistics-card {
+        flex: 1 1 100% !important;
+        max-width: 280px !important;
+        min-width: 180px !important;
+        padding: 10px !important;
+    }
+
+    .statistics-component h2 {
+        font-size: 1.5rem !important;
+    }
+}
+
+@media (max-width: 480px) {
+    .statistics-component {
+        padding: 0 !important;
+    }
+
+    .statistics-component .statistics-card {
+        flex: 1 1 100% !important;
+        max-width: 34vw !important;
+        min-width: 90px !important;
+        padding: 5px !important;
+    }
+
+    .statistics-component h2 {
+        font-size: 1rem !important;
+    }
+}


### PR DESCRIPTION
## Summary
- load secondary home sections with dynamic imports and viewport-triggered defer blocks to reduce the initial bundle
- replace Angular Material usage in navigator, stats, and contact-me with Material Symbols and custom form styling
- move shared dark-mode and responsive rules to global styles and drop unused Angular Material dependencies

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2aed02a6c832b8e17a479822516dc