### PR TITLE
Fix preview builds by disabling font inlining

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -46,7 +46,14 @@
             "ssr": {
               "entry": "server.ts"
             },
-            "baseHref": "/portfolio/"
+            "baseHref": "/portfolio/",
+            "optimization": {
+              "scripts": true,
+              "styles": true,
+              "fonts": {
+                "inline": false
+              }
+            }
           },
           "configurations": {
             "production": {


### PR DESCRIPTION
## Summary
- disable font inlining in the Angular build to stop Google Fonts fetch failures during preview deployments

## Testing
- npm run build -- --output-path=dist/portfolio --base-href=/portfolio/previews/pr-76/


------
https://chatgpt.com/codex/tasks/task_e_68e2b9dd6e68832b9cb039aa48d48943