### PR TITLE
Fix preview deployment base href

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -41,7 +41,7 @@
               "src/styles/styles.scss"
             ],
             "scripts": [],
-            "baseHref": "/portfolio/"
+            "baseHref": "./"
           },
           "configurations": {
             "production": {
@@ -58,7 +58,7 @@
                 }
               ],
               "outputHashing": "all",
-              "baseHref": "/portfolio/"
+              "baseHref": "./"
             },
             "development": {
               "optimization": false,

--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8">
   <title>Diego's Portfolio</title>
-  <base href="/">
+  <base href="./">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
   <!-- Google Analytics setup -->


### PR DESCRIPTION
## Summary
- make the Angular build use a relative base href so preview deployments resolve assets correctly
- align the index.html base tag with the relative base for consistency across environments

## Testing
- npm run build *(fails locally because Google Fonts inlining returns HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e2cbbcf010832ba00bcc760799515d