### PR TITLE
Add persistent navigator toggle and scroll auto-close behavior

### DIFF
--- a/src/app/components/navigator/navigator.component.html
+++ b/src/app/components/navigator/navigator.component.html
@@ -1,67 +1,71 @@
-<!-- Floating toggle button -->
-<button class="nav-toggle-button" *ngIf="!isOpen" (click)="toggleNavigator()" aria-label="Open navigator">
-  <mat-icon>chevron_left</mat-icon>
-</button>
+<div class="navigator-wrapper">
+  <!-- Toggle button always available -->
+  <button class="nav-toggle-button" (click)="toggleNavigator()"
+    [attr.aria-expanded]="isOpen"
+    [attr.aria-label]="isOpen ? 'Close navigator' : 'Open navigator'">
+    <mat-icon>{{ isOpen ? 'expand_more' : 'expand_less' }}</mat-icon>
+  </button>
 
-<!-- Modern, animated, circular floating navbar -->
-<div class="modern-navigator" *ngIf="isOpen">
-  <div class="arrow-container">
-    <!-- Previous button -->
-    <button class="arrow-button" *ngIf="currentSectionIndex > 0" (click)="onPrevious()" aria-label="Previous section"
-      [matTooltip]="getTooltip('prev')" matTooltipPosition="left">
-      <mat-icon>arrow_upward</mat-icon>
-    </button>
+  <!-- Modern, animated, circular floating navbar -->
+  <div class="modern-navigator" *ngIf="isOpen">
+    <div class="arrow-container">
+      <!-- Previous button -->
+      <button class="arrow-button" *ngIf="currentSectionIndex > 0" (click)="onPrevious()" aria-label="Previous section"
+        [matTooltip]="getTooltip('prev')" matTooltipPosition="left">
+        <mat-icon>arrow_upward</mat-icon>
+      </button>
 
-    <!-- Next button -->
-    <button class="arrow-button" *ngIf="currentSectionIndex < totalSections - 1" (click)="onNext()" aria-label="Next section"
-      [matTooltip]="getTooltip('next')" matTooltipPosition="left">
-      <mat-icon>arrow_downward</mat-icon>
-    </button>
-  </div>
-
-  <div class="nav-group">
-    <button class="nav-button" (click)="toggleThemeOptions()" aria-label="Theme selector"
-      [matTooltip]="getTooltip('theme')" matTooltipPosition="left">
-      <mat-icon>{{ getThemeIcon(currentTheme) }}</mat-icon>
-    </button>
-    <div class="option-container" *ngIf="showThemeOptions">
-      <button class="option-button" (click)="changeTheme('light')" aria-label="Light mode"
-        [class.selected]="currentTheme === 'light'">
-        <mat-icon>light_mode</mat-icon>
-      </button>
-      <button class="option-button" (click)="changeTheme('dark')" aria-label="Dark mode"
-        [class.selected]="currentTheme === 'dark'">
-        <mat-icon>dark_mode</mat-icon>
-      </button>
-      <button class="option-button" (click)="changeTheme('blue')" aria-label="Blue mode"
-        [class.selected]="currentTheme === 'blue'">
-        <mat-icon>water_drop</mat-icon>
-      </button>
-      <button class="option-button" (click)="changeTheme('green')" aria-label="Green mode"
-        [class.selected]="currentTheme === 'green'">
-        <mat-icon>eco</mat-icon>
+      <!-- Next button -->
+      <button class="arrow-button" *ngIf="currentSectionIndex < totalSections - 1" (click)="onNext()" aria-label="Next section"
+        [matTooltip]="getTooltip('next')" matTooltipPosition="left">
+        <mat-icon>arrow_downward</mat-icon>
       </button>
     </div>
-  </div>
 
-  <div class="nav-group">
-    <button class="nav-button" (click)="toggleLanguageOptions()" [matTooltip]="getTooltip('language')"
-      matTooltipPosition="left">
-      <span class="lang-label">{{ currentLang | slice:0:3 | uppercase }}</span>
-    </button>
-    <div class="option-container" *ngIf="showLanguageOptions">
-      <button class="option-button" (click)="changeLanguage('en')" aria-label="English">
-        <span class="lang-flag">🇬🇧</span>
+    <div class="nav-group">
+      <button class="nav-button" (click)="toggleThemeOptions()" aria-label="Theme selector"
+        [matTooltip]="getTooltip('theme')" matTooltipPosition="left">
+        <mat-icon>{{ getThemeIcon(currentTheme) }}</mat-icon>
       </button>
-      <button class="option-button" (click)="changeLanguage('it')" aria-label="Italiano">
-        <span class="lang-flag">🇮🇹</span>
+      <div class="option-container" *ngIf="showThemeOptions">
+        <button class="option-button" (click)="changeTheme('light')" aria-label="Light mode"
+          [class.selected]="currentTheme === 'light'">
+          <mat-icon>light_mode</mat-icon>
+        </button>
+        <button class="option-button" (click)="changeTheme('dark')" aria-label="Dark mode"
+          [class.selected]="currentTheme === 'dark'">
+          <mat-icon>dark_mode</mat-icon>
+        </button>
+        <button class="option-button" (click)="changeTheme('blue')" aria-label="Blue mode"
+          [class.selected]="currentTheme === 'blue'">
+          <mat-icon>water_drop</mat-icon>
+        </button>
+        <button class="option-button" (click)="changeTheme('green')" aria-label="Green mode"
+          [class.selected]="currentTheme === 'green'">
+          <mat-icon>eco</mat-icon>
+        </button>
+      </div>
+    </div>
+
+    <div class="nav-group">
+      <button class="nav-button" (click)="toggleLanguageOptions()" [matTooltip]="getTooltip('language')"
+        matTooltipPosition="left">
+        <span class="lang-label">{{ currentLang | slice:0:3 | uppercase }}</span>
       </button>
-      <button class="option-button" (click)="changeLanguage('de')" aria-label="Deutsch">
-        <span class="lang-flag">🇩🇪</span>
-      </button>
-      <button class="option-button" (click)="changeLanguage('es')" aria-label="Español">
-        <span class="lang-flag">🇪🇸</span>
-      </button>
+      <div class="option-container" *ngIf="showLanguageOptions">
+        <button class="option-button" (click)="changeLanguage('en')" aria-label="English">
+          <span class="lang-flag">🇬🇧</span>
+        </button>
+        <button class="option-button" (click)="changeLanguage('it')" aria-label="Italiano">
+          <span class="lang-flag">🇮🇹</span>
+        </button>
+        <button class="option-button" (click)="changeLanguage('de')" aria-label="Deutsch">
+          <span class="lang-flag">🇩🇪</span>
+        </button>
+        <button class="option-button" (click)="changeLanguage('es')" aria-label="Español">
+          <span class="lang-flag">🇪🇸</span>
+        </button>
+      </div>
     </div>
   </div>
 </div>

--- a/src/app/components/navigator/navigator.component.scss
+++ b/src/app/components/navigator/navigator.component.scss
@@ -82,10 +82,18 @@ $navigator-themes: (
     }
 }
 
-.nav-toggle-button {
+.navigator-wrapper {
     position: fixed;
     bottom: 30px;
     right: 30px;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 12px;
+    z-index: 9999;
+}
+
+.nav-toggle-button {
     width: $navigator-button-size;
     height: $navigator-button-size;
     border-radius: 50%;
@@ -97,7 +105,7 @@ $navigator-themes: (
     justify-content: center;
     animation: float 3s ease-in-out infinite;
     cursor: pointer;
-    z-index: 9999;
+    align-self: flex-end;
 
     mat-icon {
         position: absolute;
@@ -111,12 +119,10 @@ $navigator-themes: (
 }
 
 .modern-navigator {
-    position: fixed;
-    bottom: 30px;
-    right: 30px;
     display: flex;
     flex-direction: column;
     gap: 12px;
+    align-items: center;
 
     .arrow-container {
         width: $navigator-button-size - 8;
@@ -131,8 +137,6 @@ $navigator-themes: (
         align-items: center;
         gap: 6px;
     }
-
-    z-index: 9999;
 
     .nav-button {
         width: $navigator-button-size;

--- a/src/app/components/navigator/navigator.component.spec.ts
+++ b/src/app/components/navigator/navigator.component.spec.ts
@@ -52,6 +52,33 @@ describe('NavigatorComponent', () => {
     expect(component.navigatePrevious.emit).toHaveBeenCalled();
   });
 
+  it('should close navigator and reset menus when toggle button is clicked', () => {
+    component.isOpen = true;
+    component.showLanguageOptions = true;
+    component.showThemeOptions = true;
+    fixture.detectChanges();
+
+    const toggleButton: HTMLButtonElement = fixture.nativeElement.querySelector('.nav-toggle-button');
+    toggleButton.click();
+    fixture.detectChanges();
+
+    expect(component.isOpen).toBeFalse();
+    expect(component.showLanguageOptions).toBeFalse();
+    expect(component.showThemeOptions).toBeFalse();
+  });
+
+  it('should close navigator and reset menus on window scroll', () => {
+    component.isOpen = true;
+    component.showLanguageOptions = true;
+    component.showThemeOptions = true;
+
+    component.onWindowScroll();
+
+    expect(component.isOpen).toBeFalse();
+    expect(component.showLanguageOptions).toBeFalse();
+    expect(component.showThemeOptions).toBeFalse();
+  });
+
   /**
    * Verifies that the navigation buttons are displayed conditionally.
    */

--- a/src/app/components/navigator/navigator.component.ts
+++ b/src/app/components/navigator/navigator.component.ts
@@ -155,12 +155,31 @@ export class NavigatorComponent implements OnInit {
 
   /** Toggles navigator visibility */
   toggleNavigator(): void {
-    this.isOpen = !this.isOpen;
+    if (this.isOpen) {
+      this.closeNavigator();
+    } else {
+      this.openNavigator();
+    }
   }
 
   /** Opens the navigator */
   openNavigator(): void {
     this.isOpen = true;
+    this.resetOptionMenus();
+  }
+
+  /** Closes the navigator and resets option menus */
+  closeNavigator(): void {
+    if (!this.isOpen) {
+      return;
+    }
+    this.isOpen = false;
+    this.resetOptionMenus();
+  }
+
+  private resetOptionMenus(): void {
+    this.showLanguageOptions = false;
+    this.showThemeOptions = false;
   }
 
   /** Host listener to detect clicks outside and close */
@@ -168,7 +187,15 @@ export class NavigatorComponent implements OnInit {
   onDocumentClick(target: HTMLElement): void {
     const clickedInside = this.elementRef.nativeElement.contains(target);
     if (!clickedInside && this.isOpen) {
-      this.isOpen = false;
+      this.closeNavigator();
+    }
+  }
+
+  /** Host listener to close navigator on scroll */
+  @HostListener('window:scroll')
+  onWindowScroll(): void {
+    if (this.isOpen) {
+      this.closeNavigator();
     }
   }
 }


### PR DESCRIPTION
## Summary
- keep the navigator toggle button available at all times with updated icons and ARIA attributes
- wrap and restyle the floating navigator controls so the toggle sits above the panel
- ensure the navigator closes and resets option menus when toggled, clicking outside, or scrolling, and cover the new flows with unit tests

## Testing
- CI=true npm run test -- --watch=false *(fails: ChromeHeadless missing libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68e2d1856674832bb0d3df3d912f2dd7