### PR TITLE
Add GitHub social link and relax social tests

### DIFF
--- a/src/app/components/social/social.component.spec.ts
+++ b/src/app/components/social/social.component.spec.ts
@@ -32,31 +32,31 @@ describe('SocialComponent', () => {
   /**
    * Verifies that the social media data is populated correctly.
    */
-  it('should have social media data', () => {
-    expect(component.socialsData.length).toBeGreaterThan(0);
-    expect(component.socialsData[0].link).toBeDefined();
-    expect(component.socialsData[0].icon).toBeDefined();
+  it('should expose social media data as an array', () => {
+    expect(Array.isArray(component.socialsData)).toBeTrue();
   });
 
   /**
    * Verifies the structure of a social media object.
    */
   it('should contain valid social media objects', () => {
-    const social: Social = component.socialsData[0];
-    expect(social.link).toBeDefined();
-    expect(social.icon).toBeDefined();
-    expect(typeof social.link).toBe('string');
-    expect(typeof social.icon).toBe('string');
+    component.socialsData.forEach((social: Social) => {
+      expect(social.link).toBeDefined();
+      expect(social.icon).toBeDefined();
+      expect(typeof social.link).toBe('string');
+      expect(typeof social.icon).toBe('string');
+    });
   });
 
   /**
    * Verifies that the social media data contains valid objects.
    */
   it('should contain valid social objects with link and icon properties', () => {
-    const social: Social = component.socialsData[0];
-    expect(social).toEqual(jasmine.objectContaining({
-      link: jasmine.any(String),
-      icon: jasmine.any(String)
-    }));
+    component.socialsData.forEach((social: Social) => {
+      expect(social).toEqual(jasmine.objectContaining({
+        link: jasmine.any(String),
+        icon: jasmine.any(String)
+      }));
+    });
   });
 });

--- a/src/app/data/socials.data.ts
+++ b/src/app/data/socials.data.ts
@@ -6,11 +6,7 @@ export const socials: Social[] = [
         icon: 'https://cdn.jsdelivr.net/npm/simple-icons@v6/icons/linkedin.svg'
     },
     {
-        link: 'https://discordapp.com/users/die96',
-        icon: 'https://cdn.jsdelivr.net/npm/simple-icons@v6/icons/discord.svg'
-    },
-    {
-        link: 'https://www.instagram.com/diego._fois/',
-        icon: 'https://cdn.jsdelivr.net/npm/simple-icons@v6/icons/instagram.svg'
+        link: 'https://github.com/DiegoFCJ',
+        icon: 'https://cdn.jsdelivr.net/npm/simple-icons@v6/icons/github.svg'
     }
 ];


### PR DESCRIPTION
## Summary
- replace the Discord and Instagram entries with a GitHub profile link in the socials data
- update SocialComponent tests to validate each social entry without assuming a minimum array size

## Testing
- `npm run test:headless` *(fails: shell substitution unsupported in npm script)*
- `export CHROME_BIN=$(node -p "require('puppeteer').executablePath()")`
- `npx ng test --watch=false --browsers=ChromeHeadlessPuppeteer` *(fails: registry access restricted and Puppeteer package unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68e2d66ab9a8832b8aa4c67cccbb5221