### PR TITLE
Update stats cards with realistic portfolio metrics

### DIFF
--- a/src/app/data/stats.data.ts
+++ b/src/app/data/stats.data.ts
@@ -4,37 +4,37 @@ export const statsData: Stats = {
     en: {
         title: 'Statistics',
         stats: [
-            { icon: 'history', label: 'Total Hours', value: '0' },
-            { icon: 'today', label: 'Total Months', value: '0' },
-            { icon: 'work', label: 'Projects', value: '0' },
-            { icon: 'apps', label: 'Most Used', value: 'Spring Boot, Java, Angular, MYSQL' },
+            { icon: 'today', label: 'Total Months', value: '73+ months of experience' },
+            { icon: 'work', label: 'Projects Delivered', value: '6 major initiatives' },
+            { icon: 'autorenew', label: 'Processes Automated', value: '10+ end-to-end workflows' },
+            { icon: 'code', label: 'Core Stack', value: 'Spring Boot · Java · Angular · MySQL' },
         ]
     },
     it: {
         title: 'Statistiche',
         stats: [
-            { icon: 'history', label: 'Ore Totali', value: '0' },
-            { icon: 'today', label: 'Mesi Totali', value: '0' },
-            { icon: 'work', label: 'Progetti', value: '0' },
-            { icon: 'apps', label: 'Più Usato', value: 'Spring Boot, Java, Angular, MYSQL' },
+            { icon: 'today', label: 'Mesi Totali', value: '73+ mesi di esperienza' },
+            { icon: 'work', label: 'Progetti Consegnati', value: '6 iniziative principali' },
+            { icon: 'autorenew', label: 'Processi Automatizzati', value: '10+ flussi end-to-end' },
+            { icon: 'code', label: 'Stack Principale', value: 'Spring Boot · Java · Angular · MySQL' },
         ]
     },
     de: {
         title: 'Statistiken',
         stats: [
-            { icon: 'history', label: 'Gesamtstunden', value: '0' },
-            { icon: 'today', label: 'Gesamtmonate', value: '0' },
-            { icon: 'work', label: 'Projekte', value: '0' },
-            { icon: 'apps', label: 'Meistgenutzt', value: 'Spring Boot, Java, Angular, MYSQL' },
+            { icon: 'today', label: 'Gesamtmonate', value: '73+ Monate Erfahrung' },
+            { icon: 'work', label: 'Abgeschlossene Projekte', value: '6 zentrale Initiativen' },
+            { icon: 'autorenew', label: 'Automatisierte Prozesse', value: 'Über 10 End-to-End-Workflows' },
+            { icon: 'code', label: 'Kerntechnologien', value: 'Spring Boot · Java · Angular · MySQL' },
         ]
     },
     es: {
         title: 'Estadísticas',
         stats: [
-            { icon: 'history', label: 'Horas Totales', value: '0' },
-            { icon: 'today', label: 'Meses Totales', value: '0' },
-            { icon: 'work', label: 'Proyectos', value: '0' },
-            { icon: 'apps', label: 'Más Usado', value: 'Spring Boot, Java, Angular, MYSQL' },
+            { icon: 'today', label: 'Meses Totales', value: '73+ meses de experiencia' },
+            { icon: 'work', label: 'Proyectos Entregados', value: '6 iniciativas clave' },
+            { icon: 'autorenew', label: 'Procesos Automatizados', value: 'Más de 10 flujos end-to-end' },
+            { icon: 'code', label: 'Tecnologías Clave', value: 'Spring Boot · Java · Angular · MySQL' },
         ]
     }
 };


### PR DESCRIPTION
## Summary
- refresh the statistics data with realistic totals for experience, projects, automation, and tech stack
- align English, Italian, German, and Spanish labels and values with the new metrics

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2d66aebe8832b993810ea4503549f