### PR TITLE
Add company metadata and bullet list rendering to experiences

### DIFF
--- a/src/app/components/experiences/experiences.component.html
+++ b/src/app/components/experiences/experiences.component.html
@@ -2,10 +2,17 @@
     <h2>{{ experiences.title }}</h2>
     <div class="experiences-container">
         <div class="experience" *ngFor="let experience of experiences.experiences">
-            <p><strong>{{ experience.startDate }} - {{ experience.endDate }}</strong></p>
-            <p>{{ experience.location }} - <strong>{{ experience.position }}</strong></p>
-            <p *ngIf="experience.technologies">{{ experience.technologies }}</p>
-            <p>{{ experience.responsibilities }}</p>
+            <p class="experience-period"><strong>{{ experience.startDate }} - {{ experience.endDate }}</strong></p>
+            <p class="experience-title">
+                <strong>{{ experience.position }}</strong>
+                <span *ngIf="experience.company"> · {{ experience.company }}</span>
+            </p>
+            <p class="experience-location">{{ experience.location }}</p>
+            <p *ngIf="experience.technologies" class="experience-technologies">{{ experience.technologies }}</p>
+            <p *ngIf="experience.responsibilities">{{ experience.responsibilities }}</p>
+            <ul *ngIf="experience.responsibilityList?.length" class="responsibility-list">
+                <li *ngFor="let item of experience.responsibilityList">{{ item }}</li>
+            </ul>
         </div>
     </div>
 </section>

--- a/src/app/components/experiences/experiences.component.scss
+++ b/src/app/components/experiences/experiences.component.scss
@@ -24,7 +24,32 @@
         p {
             text-align: start;
             margin: 0;
-            padding: 5px;
+            padding: 4px 0;
+        }
+
+        .experience-title {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 4px;
+        }
+
+        .experience-location,
+        .experience-period {
+            font-size: 0.95rem;
+        }
+
+        .experience-technologies {
+            font-style: italic;
+        }
+
+        .responsibility-list {
+            margin: 8px 0 0;
+            padding-left: 20px;
+
+            li {
+                text-align: start;
+                margin-bottom: 4px;
+            }
         }
     }
 }

--- a/src/app/data/experiences.data.ts
+++ b/src/app/data/experiences.data.ts
@@ -6,57 +6,100 @@ export const experiencesData: ExperienceFullLangs = {
         experiences: [
             {
                 position: 'Software Developer',
+                company: 'Engineering Ingegneria Informatica S.p.A.',
                 location: 'Full Remote',
                 startDate: 'Apr 2024',
                 endDate: 'Jun 2025',
                 technologies: 'Spring Boot (3.0), Java 21, JavaFX, Angular (18), Shell, YAML, AngularJS, Python',
-                responsibilities: 'Concluded the engagement after automating processes and optimizing activities, including bug fixing. Enhanced operational efficiency by streamlining tasks and improving the overall user experience through modern technologies.'
+                responsibilities: 'Led the modernization of internal service-management platforms for public administration customers.',
+                responsibilityList: [
+                    'Automated manual AMS triage through Java 21 workflows and Shell scripts to accelerate ticket resolution.',
+                    'Migrated legacy AngularJS dashboards to Angular 18, improving usability and accessibility for operators.',
+                    'Coordinated with distributed stakeholders to prioritise bug fixing and schedule releases.'
+                ]
             },
             {
                 position: 'Software Developer',
+                company: 'Reply S.p.A.',
                 location: 'Hybrid, Turin',
                 startDate: 'Jan 2025',
                 endDate: 'Jun 2025',
                 technologies: 'Spring Boot, .NET, Node.js, MySQL, Angular 14',
-                responsibilities: 'Implemented a custom logging system for Linux servers, automated daily process monitoring, fixed critical bugs and integrated new features using Boomi.'
+                responsibilities: 'Supported enterprise integration programmes for a banking client.',
+                responsibilityList: [
+                    'Implemented custom logging pipelines on Linux servers with Java and Shell to satisfy audit requirements.',
+                    'Automated daily process monitoring and reporting through scheduled scripts and dashboards.',
+                    'Integrated Dell Boomi flows with Spring Boot and .NET services to expose new customer features.',
+                    'Facilitated knowledge-sharing sessions to align developers, testers, and operations teams.'
+                ]
             },
             {
                 position: 'Software Developer',
+                company: 'Engineering Ingegneria Informatica S.p.A.',
                 location: 'Full Remote',
                 startDate: 'Apr 2024',
                 endDate: 'Oct 2024',
                 technologies: 'Spring Boot, AngularJS, JSP, Java',
-                responsibilities: 'Implemented new features and resolved critical issues for legacy projects. Automated daily tasks for the AMS team using Java.'
+                responsibilities: 'Delivered corrective and evolutive maintenance on legacy platforms.',
+                responsibilityList: [
+                    'Resolved critical bugs and delivered evolutive changes on JSP and AngularJS modules.',
+                    'Automated recurring AMS activities with Java schedulers, reducing manual intervention.',
+                    'Documented troubleshooting guides to support the on-call rotation.'
+                ]
             },
             {
                 position: 'Software Developer',
+                company: 'Engineering Ingegneria Informatica S.p.A.',
                 location: 'Full Remote',
                 startDate: 'Oct 2023',
                 endDate: 'Apr 2024',
                 technologies: 'Spring Boot (3.1.7), Java 17, Angular 16, JWT, Argon2, MySQL, Git',
-                responsibilities: 'Implemented back-end and front-end solutions for internal projects, including repository management and application deployment.'
+                responsibilities: 'Enhanced internal products with secure back-end and front-end capabilities.',
+                responsibilityList: [
+                    'Implemented Spring Boot microservices secured with JWT and Argon2-based authentication.',
+                    'Developed Angular 16 modules for the repository management portal.',
+                    'Automated deployment workflows by scripting Git-based release procedures.'
+                ]
             },
             {
                 position: 'Software Developer',
+                company: 'Engineering Ingegneria Informatica S.p.A.',
                 location: 'Hybrid',
                 startDate: 'Feb 2023',
                 endDate: 'Oct 2023',
                 technologies: 'Java 8, Spring Boot, MySQL, Angular 7, Docker, OpenShift',
-                responsibilities: 'Developed internal applications and contributed to the deployment of both monolithic and microservice-based applications. Utilized OpenShift for container orchestration and focused on seamless deployment of front-end and back-end pods.'
+                responsibilities: 'Contributed to the development and deployment of internal platforms for energy sector clients.',
+                responsibilityList: [
+                    'Developed features for Spring Boot and Angular 7 applications supporting monitoring services.',
+                    'Containerised workloads with Docker and orchestrated deployments on OpenShift.',
+                    'Collaborated with DevOps teams to coordinate multi-squad releases and hotfixes.'
+                ]
             },
             {
                 position: 'Head Waiter',
+                company: 'D&D London',
                 location: 'London',
                 startDate: 'Dec 2018',
                 endDate: 'Mar 2020',
-                responsibilities: 'Managed operations across multiple restaurant locations, coordinating staff and ensuring excellent customer service. Developed strong interpersonal and communication skills, contributing to improved customer satisfaction and efficient service delivery.'
+                responsibilities: 'Oversaw floor operations for premium dining venues.',
+                responsibilityList: [
+                    'Coordinated waiting staff schedules across multiple restaurants to guarantee service coverage.',
+                    'Trained new hires on fine-dining procedures, safety rules, and POS systems.',
+                    'Acted as liaison between kitchen, bar, and front of house to maintain service quality.'
+                ]
             },
             {
                 position: 'National Civil Service Rescuer',
+                company: 'Croce Rossa Italiana',
                 location: 'Italy',
                 startDate: 'Oct 2017',
                 endDate: 'Oct 2018',
-                responsibilities: 'Provided support to emergency services, learning to manage stress and maintain composure in high-pressure situations. Developed strong problem-solving and teamwork skills while assisting in various non-critical rescue operations and community support initiatives.'
+                responsibilities: 'Supported emergency response initiatives as a national civil service volunteer.',
+                responsibilityList: [
+                    'Assisted ambulance teams during non-critical interventions and community outreach programmes.',
+                    'Managed radio communications and logged incidents to support emergency crews.',
+                    'Delivered first-aid awareness sessions alongside local volunteers.'
+                ]
             }
         ]
     },
@@ -65,57 +108,100 @@ export const experiencesData: ExperienceFullLangs = {
         experiences: [
             {
                 position: 'Sviluppatore Software',
+                company: 'Engineering Ingegneria Informatica S.p.A.',
                 location: 'Full Remote',
                 startDate: 'Apr 2024',
                 endDate: 'Giu 2025',
                 technologies: 'Spring Boot (3.0), Java 21, JavaFX, Angular (18), Shell, YAML, AngularJS, Python',
-                responsibilities: 'Concluso l\'incarico dopo aver automatizzato processi e ottimizzato le attività, inclusa la risoluzione di bug. Migliorata l\'efficienza operativa grazie all\'uso di tecnologie moderne.'
+                responsibilities: 'Guidato la modernizzazione delle piattaforme di service management per clienti della Pubblica Amministrazione.',
+                responsibilityList: [
+                    'Automazione del triage AMS attraverso workflow Java 21 e script Shell riducendo i tempi di gestione ticket.',
+                    'Migrazione delle dashboard AngularJS verso Angular 18 per migliorare usabilità e accessibilità.',
+                    'Coordinamento con stakeholder distribuiti per prioritizzare bug fixing e pianificare i rilasci.'
+                ]
             },
             {
                 position: 'Sviluppatore Software',
+                company: 'Reply S.p.A.',
                 location: 'Ibrido, Torino',
                 startDate: 'Gen 2025',
                 endDate: 'Giu 2025',
                 technologies: 'Spring Boot, .NET, Node.js, MySQL, Angular 14',
-                responsibilities: 'Implementazione di un sistema di custom logging su server Linux, monitoraggio giornaliero dei processi con relativa automazione, bug fixing e integrazione di funzionalità con Boomi.'
+                responsibilities: 'Supporto a programmi di integrazione enterprise per un cliente bancario.',
+                responsibilityList: [
+                    'Implementazione di pipeline di logging personalizzate su server Linux con Java e Shell per soddisfare i requisiti di audit.',
+                    'Automazione del monitoraggio giornaliero e della reportistica tramite script schedulati e dashboard dedicate.',
+                    'Integrazione dei flussi Dell Boomi con servizi Spring Boot e .NET per esporre nuove funzionalità ai clienti.',
+                    'Conduzione di sessioni di knowledge sharing tra team di sviluppo, test e operation.'
+                ]
             },
             {
                 position: 'Sviluppatore Software',
+                company: 'Engineering Ingegneria Informatica S.p.A.',
                 location: 'Full Remote',
                 startDate: 'Apr 2024',
                 endDate: 'Ott 2024',
                 technologies: 'Spring Boot, AngularJS, JSP, Java',
-                responsibilities: 'Implementazione di evolutive in progetti esistenti e risoluzione di bug critici. Automazione delle attività quotidiane del team AMS tramite Java.'
+                responsibilities: 'Manutenzione correttiva ed evolutiva di piattaforme legacy.',
+                responsibilityList: [
+                    'Risoluzione di bug critici e rilascio di evolutive su moduli JSP e AngularJS.',
+                    'Automazione delle attività ricorrenti AMS con scheduler Java riducendo il lavoro manuale.',
+                    'Redazione di guide operative a supporto della reperibilità.'
+                ]
             },
             {
                 position: 'Sviluppatore Software',
+                company: 'Engineering Ingegneria Informatica S.p.A.',
                 location: 'Full Remote',
                 startDate: 'Ott 2023',
                 endDate: 'Apr 2024',
                 technologies: 'Spring Boot (3.1.7), Java 17, Angular 16, JWT, Argon2, MySQL, Git',
-                responsibilities: 'Sviluppo di soluzioni backend e frontend per progetti interni con gestione del repository e deployment applicativo.'
+                responsibilities: 'Evoluzione di prodotti interni con funzionalità backend e frontend sicure.',
+                responsibilityList: [
+                    'Implementazione di microservizi Spring Boot protetti con autenticazione JWT e Argon2.',
+                    'Sviluppo di moduli Angular 16 per il portale di gestione repository.',
+                    'Automazione dei workflow di deployment tramite procedure di rilascio basate su Git.'
+                ]
             },
             {
                 position: 'Sviluppatore Software',
+                company: 'Engineering Ingegneria Informatica S.p.A.',
                 location: 'Ibrido',
                 startDate: 'Feb 2023',
                 endDate: 'Ott 2023',
                 technologies: 'Java 8, Spring Boot, MySQL, Angular 7, Docker, OpenShift',
-                responsibilities: 'Sviluppo di applicazioni interne e contributo al deployment di applicazioni monolitiche e basate su microservizi. Utilizzo di OpenShift per l\'orchestrazione dei container e deployment dei pod frontend e backend.'
+                responsibilities: 'Contributo allo sviluppo e al deployment di piattaforme interne per clienti del settore energia.',
+                responsibilityList: [
+                    'Sviluppo di funzionalità per applicazioni Spring Boot e Angular 7 dedicate ai servizi di monitoraggio.',
+                    'Containerizzazione dei workload con Docker e orchestrazione dei rilasci su OpenShift.',
+                    'Collaborazione con i team DevOps per coordinare rilasci multi-squad e hotfix.'
+                ]
             },
             {
                 position: 'Capo Cameriere',
+                company: 'D&D London',
                 location: 'Londra',
                 startDate: 'Dic 2018',
                 endDate: 'Mar 2020',
-                responsibilities: 'Gestione delle operazioni in diverse sedi di ristoranti, coordinamento del personale e garanzia di un eccellente servizio clienti. Sviluppo di competenze interpersonali e comunicative, migliorando la soddisfazione dei clienti e l\'efficienza del servizio.'
+                responsibilities: 'Supervisione delle operazioni di sala in ristoranti di fascia alta.',
+                responsibilityList: [
+                    'Coordinamento dei turni del personale di sala in più sedi garantendo copertura del servizio.',
+                    'Formazione dei nuovi assunti su procedure fine dining, norme di sicurezza e sistemi POS.',
+                    'Interfaccia costante con cucina e bar per mantenere alto lo standard del servizio.'
+                ]
             },
             {
                 position: 'Volontario Servizio Civile Nazionale',
+                company: 'Croce Rossa Italiana',
                 location: 'Italia',
                 startDate: 'Ott 2017',
                 endDate: 'Ott 2018',
-                responsibilities: 'Supporto ai servizi di emergenza, con acquisizione di capacità per gestire lo stress e mantenere la calma in situazioni di alta pressione. Sviluppo di competenze di problem-solving e lavoro di squadra, assistendo in operazioni di salvataggio non critiche e in iniziative di supporto alla comunità.'
+                responsibilities: 'Supporto alle attività di risposta alle emergenze come volontario del Servizio Civile.',
+                responsibilityList: [
+                    'Affiancamento alle squadre di ambulanza durante interventi non critici e iniziative di sensibilizzazione.',
+                    'Gestione delle comunicazioni radio e registrazione degli interventi a supporto degli equipaggi.',
+                    'Erogazione di sessioni informative di primo soccorso insieme ai volontari locali.'
+                ]
             }
         ]
     },
@@ -123,58 +209,101 @@ export const experiencesData: ExperienceFullLangs = {
         title: 'Erfahrung',
         experiences: [
             {
-                position: 'Software Developer',
-                location: 'Full Remote',
+                position: 'Softwareentwickler',
+                company: 'Engineering Ingegneria Informatica S.p.A.',
+                location: 'Voll Remote',
                 startDate: 'Apr 2024',
                 endDate: 'Jun 2025',
                 technologies: 'Spring Boot (3.0), Java 21, JavaFX, Angular (18), Shell, YAML, AngularJS, Python',
-                responsibilities: 'Concluded the engagement after automating processes and optimizing activities, including bug fixing. Enhanced operational efficiency by streamlining tasks and improving the overall user experience through modern technologies.'
+                responsibilities: 'Leitete die Modernisierung von Service-Management-Plattformen für öffentliche Kunden.',
+                responsibilityList: [
+                    'Automatisierung des AMS-Triage mit Java-21-Workflows und Shell-Skripten zur Beschleunigung der Ticketbearbeitung.',
+                    'Migration von AngularJS-Dashboards nach Angular 18 zur Verbesserung der Benutzerfreundlichkeit.',
+                    'Abstimmung mit verteilten Stakeholdern zur Priorisierung von Bugfixes und Release-Planung.'
+                ]
             },
             {
-                position: 'Software Developer',
+                position: 'Softwareentwickler',
+                company: 'Reply S.p.A.',
                 location: 'Hybrid, Turin',
                 startDate: 'Jan 2025',
                 endDate: 'Jun 2025',
                 technologies: 'Spring Boot, .NET, Node.js, MySQL, Angular 14',
-                responsibilities: 'Implemented a custom logging system for Linux servers, automated daily process monitoring, fixed critical bugs and integrated new features using Boomi.'
+                responsibilities: 'Unterstützte Integrationsprogramme für einen Bankkunden.',
+                responsibilityList: [
+                    'Aufbau individueller Logging-Pipelines auf Linux-Servern mit Java und Shell für Prüfanforderungen.',
+                    'Automatisierung des täglichen Prozessmonitorings und der Berichte mittels geplanter Skripte und Dashboards.',
+                    'Integration von Dell-Boomi-Flows mit Spring-Boot- und .NET-Services zur Bereitstellung neuer Funktionen.',
+                    'Durchführung von Wissensaustausch-Sessions zur Abstimmung von Entwicklung, Test und Betrieb.'
+                ]
             },
             {
-                position: 'Software Developer',
-                location: 'Full Remote',
+                position: 'Softwareentwickler',
+                company: 'Engineering Ingegneria Informatica S.p.A.',
+                location: 'Voll Remote',
                 startDate: 'Apr 2024',
                 endDate: 'Oct 2024',
                 technologies: 'Spring Boot, AngularJS, JSP, Java',
-                responsibilities: 'Implemented new features and resolved critical issues for legacy projects. Automated daily tasks for the AMS team using Java.'
+                responsibilities: 'Lieferte Korrektur- und Evolutionswartung für Legacy-Plattformen.',
+                responsibilityList: [
+                    'Behebung kritischer Fehler und Umsetzung von Erweiterungen in JSP- und AngularJS-Modulen.',
+                    'Automatisierung wiederkehrender AMS-Aufgaben mit Java-Schedulern zur Verringerung manueller Tätigkeiten.',
+                    'Erstellung von Troubleshooting-Anleitungen für den Bereitschaftsdienst.'
+                ]
             },
             {
-                position: 'Software Developer',
-                location: 'Full Remote',
+                position: 'Softwareentwickler',
+                company: 'Engineering Ingegneria Informatica S.p.A.',
+                location: 'Voll Remote',
                 startDate: 'Oct 2023',
                 endDate: 'Apr 2024',
                 technologies: 'Spring Boot (3.1.7), Java 17, Angular 16, JWT, Argon2, MySQL, Git',
-                responsibilities: 'Implemented back-end and front-end solutions for internal projects, including repository management and application deployment.'
+                responsibilities: 'Erweiterte interne Produkte um sichere Backend- und Frontend-Funktionalitäten.',
+                responsibilityList: [
+                    'Implementierung von Spring-Boot-Mikroservices mit JWT- und Argon2-Authentifizierung.',
+                    'Entwicklung von Angular-16-Modulen für das Repository-Management-Portal.',
+                    'Automatisierung der Deployment-Workflows mittels Git-basierter Release-Skripte.'
+                ]
             },
             {
-                position: 'Software Developer',
+                position: 'Softwareentwickler',
+                company: 'Engineering Ingegneria Informatica S.p.A.',
                 location: 'Hybrid',
                 startDate: 'Feb 2023',
                 endDate: 'Oct 2023',
                 technologies: 'Java 8, Spring Boot, MySQL, Angular 7, Docker, OpenShift',
-                responsibilities: 'Developed internal applications and contributed to the deployment of both monolithic and microservice-based applications. Utilized OpenShift for container orchestration and focused on seamless deployment of front-end and back-end pods.'
+                responsibilities: 'Unterstützte die Entwicklung und den Rollout interner Plattformen für Kunden aus dem Energiesektor.',
+                responsibilityList: [
+                    'Entwicklung von Funktionen für Spring-Boot- und Angular-7-Anwendungen zur Überwachung von Diensten.',
+                    'Containerisierung der Workloads mit Docker und Bereitstellung auf OpenShift.',
+                    'Zusammenarbeit mit DevOps-Teams zur Koordination von Multi-Team-Releases und Hotfixes.'
+                ]
             },
             {
-                position: 'Head Waiter',
+                position: 'Oberkellner',
+                company: 'D&D London',
                 location: 'London',
                 startDate: 'Dec 2018',
                 endDate: 'Mar 2020',
-                responsibilities: 'Managed operations across multiple restaurant locations, coordinating staff and ensuring excellent customer service. Developed strong interpersonal and communication skills, contributing to improved customer satisfaction and efficient service delivery.'
+                responsibilities: 'Verantwortete den Servicebetrieb in gehobenen Restaurants.',
+                responsibilityList: [
+                    'Koordination der Einsatzpläne des Servicepersonals an mehreren Standorten.',
+                    'Einarbeitung neuer Mitarbeitender in Fine-Dining-Prozesse, Sicherheitsrichtlinien und Kassensysteme.',
+                    'Schnittstelle zwischen Küche, Bar und Service zur Sicherung der Servicequalität.'
+                ]
             },
             {
-                position: 'National Civil Service Rescuer',
-                location: 'Italy',
+                position: 'Zivildiensthelfer',
+                company: 'Croce Rossa Italiana',
+                location: 'Italien',
                 startDate: 'Oct 2017',
                 endDate: 'Oct 2018',
-                responsibilities: 'Provided support to emergency services, learning to manage stress and maintain composure in high-pressure situations. Developed strong problem-solving and teamwork skills while assisting in various non-critical rescue operations and community support initiatives.'
+                responsibilities: 'Unterstützte als Freiwilliger den Rettungsdienst.',
+                responsibilityList: [
+                    'Begleitung von Rettungsteams bei nicht-kritischen Einsätzen und Community-Aktionen.',
+                    'Führung von Funkkommunikation und Einsatzprotokollen zur Unterstützung der Teams.',
+                    'Durchführung von Erste-Hilfe-Schulungen gemeinsam mit lokalen Freiwilligen.'
+                ]
             }
         ]
     },
@@ -182,58 +311,101 @@ export const experiencesData: ExperienceFullLangs = {
         title: 'Experiencia',
         experiences: [
             {
-                position: 'Software Developer',
-                location: 'Full Remote',
-                startDate: 'Apr 2024',
+                position: 'Desarrollador de Software',
+                company: 'Engineering Ingegneria Informatica S.p.A.',
+                location: 'Totalmente remoto',
+                startDate: 'Abr 2024',
                 endDate: 'Jun 2025',
                 technologies: 'Spring Boot (3.0), Java 21, JavaFX, Angular (18), Shell, YAML, AngularJS, Python',
-                responsibilities: 'Concluded the engagement after automating processes and optimizing activities, including bug fixing. Enhanced operational efficiency by streamlining tasks and improving the overall user experience through modern technologies.'
+                responsibilities: 'Lideró la modernización de plataformas de gestión de servicios para clientes del sector público.',
+                responsibilityList: [
+                    'Automatizó el triage AMS mediante flujos de trabajo en Java 21 y scripts Shell, acelerando la resolución de tickets.',
+                    'Migró paneles de AngularJS a Angular 18 para mejorar la experiencia de los operadores.',
+                    'Coordinó con interlocutores distribuidos la priorización de correcciones y la planificación de releases.'
+                ]
             },
             {
-                position: 'Software Developer',
-                location: 'Hybrid, Turin',
-                startDate: 'Jan 2025',
+                position: 'Desarrollador de Software',
+                company: 'Reply S.p.A.',
+                location: 'Híbrido, Turín',
+                startDate: 'Ene 2025',
                 endDate: 'Jun 2025',
                 technologies: 'Spring Boot, .NET, Node.js, MySQL, Angular 14',
-                responsibilities: 'Implemented a custom logging system for Linux servers, automated daily process monitoring, fixed critical bugs and integrated new features using Boomi.'
+                responsibilities: 'Apoyó programas de integración empresarial para un cliente bancario.',
+                responsibilityList: [
+                    'Implementó canalizaciones de logging personalizadas en servidores Linux con Java y Shell para cumplir auditorías.',
+                    'Automatizó el monitoreo diario de procesos y la elaboración de informes mediante scripts programados y paneles.',
+                    'Integró flujos de Dell Boomi con servicios de Spring Boot y .NET para ofrecer nuevas funcionalidades.',
+                    'Organizó sesiones de intercambio de conocimiento entre desarrollo, pruebas y operaciones.'
+                ]
             },
             {
-                position: 'Software Developer',
-                location: 'Full Remote',
-                startDate: 'Apr 2024',
+                position: 'Desarrollador de Software',
+                company: 'Engineering Ingegneria Informatica S.p.A.',
+                location: 'Totalmente remoto',
+                startDate: 'Abr 2024',
                 endDate: 'Oct 2024',
                 technologies: 'Spring Boot, AngularJS, JSP, Java',
-                responsibilities: 'Implemented new features and resolved critical issues for legacy projects. Automated daily tasks for the AMS team using Java.'
+                responsibilities: 'Entregó mantenimiento correctivo y evolutivo en plataformas heredadas.',
+                responsibilityList: [
+                    'Resolución de errores críticos y entrega de evolutivos en módulos JSP y AngularJS.',
+                    'Automatización de tareas recurrentes de AMS con planificadores en Java para reducir el esfuerzo manual.',
+                    'Documentación de guías de resolución de problemas para el personal de guardia.'
+                ]
             },
             {
-                position: 'Software Developer',
-                location: 'Full Remote',
+                position: 'Desarrollador de Software',
+                company: 'Engineering Ingegneria Informatica S.p.A.',
+                location: 'Totalmente remoto',
                 startDate: 'Oct 2023',
-                endDate: 'Apr 2024',
+                endDate: 'Abr 2024',
                 technologies: 'Spring Boot (3.1.7), Java 17, Angular 16, JWT, Argon2, MySQL, Git',
-                responsibilities: 'Implemented back-end and front-end solutions for internal projects, including repository management and application deployment.'
+                responsibilities: 'Mejoró productos internos con funcionalidades backend y frontend seguras.',
+                responsibilityList: [
+                    'Implementó microservicios Spring Boot protegidos con autenticación JWT y Argon2.',
+                    'Desarrolló módulos en Angular 16 para el portal de gestión de repositorios.',
+                    'Automatizó flujos de despliegue mediante scripts de releases basados en Git.'
+                ]
             },
             {
-                position: 'Software Developer',
-                location: 'Hybrid',
+                position: 'Desarrollador de Software',
+                company: 'Engineering Ingegneria Informatica S.p.A.',
+                location: 'Híbrido',
                 startDate: 'Feb 2023',
                 endDate: 'Oct 2023',
                 technologies: 'Java 8, Spring Boot, MySQL, Angular 7, Docker, OpenShift',
-                responsibilities: 'Developed internal applications and contributed to the deployment of both monolithic and microservice-based applications. Utilized OpenShift for container orchestration and focused on seamless deployment of front-end and back-end pods.'
+                responsibilities: 'Contribuyó al desarrollo y despliegue de plataformas internas para clientes del sector energético.',
+                responsibilityList: [
+                    'Desarrollo de funcionalidades para aplicaciones Spring Boot y Angular 7 orientadas al monitoreo.',
+                    'Contenerización de cargas de trabajo con Docker y despliegue en OpenShift.',
+                    'Colaboración con equipos DevOps para coordinar releases multi-equipo y hotfixes.'
+                ]
             },
             {
-                position: 'Head Waiter',
-                location: 'London',
-                startDate: 'Dec 2018',
+                position: 'Jefe de Sala',
+                company: 'D&D London',
+                location: 'Londres',
+                startDate: 'Dic 2018',
                 endDate: 'Mar 2020',
-                responsibilities: 'Managed operations across multiple restaurant locations, coordinating staff and ensuring excellent customer service. Developed strong interpersonal and communication skills, contributing to improved customer satisfaction and efficient service delivery.'
+                responsibilities: 'Supervisó las operaciones de sala en restaurantes de alto nivel.',
+                responsibilityList: [
+                    'Coordinó los turnos del personal de sala en varios locales para asegurar la cobertura del servicio.',
+                    'Formó a nuevas incorporaciones en protocolos de fine dining, normas de seguridad y sistemas POS.',
+                    'Actuó como enlace entre cocina, barra y sala para mantener la calidad del servicio.'
+                ]
             },
             {
-                position: 'National Civil Service Rescuer',
-                location: 'Italy',
+                position: 'Voluntario del Servicio Civil Nacional',
+                company: 'Croce Rossa Italiana',
+                location: 'Italia',
                 startDate: 'Oct 2017',
                 endDate: 'Oct 2018',
-                responsibilities: 'Provided support to emergency services, learning to manage stress and maintain composure in high-pressure situations. Developed strong problem-solving and teamwork skills while assisting in various non-critical rescue operations and community support initiatives.'
+                responsibilities: 'Apoyó iniciativas de respuesta a emergencias como voluntario del servicio civil.',
+                responsibilityList: [
+                    'Asistencia a equipos de ambulancia durante intervenciones no críticas y acciones comunitarias.',
+                    'Gestión de comunicaciones por radio y registro de incidencias en apoyo a los equipos de emergencia.',
+                    'Impartición de sesiones de sensibilización sobre primeros auxilios junto a voluntarios locales.'
+                ]
             }
         ]
     }

--- a/src/app/dtos/ExperienceDTO.ts
+++ b/src/app/dtos/ExperienceDTO.ts
@@ -13,9 +13,11 @@ export interface ExperienceFull {
 
 export interface Experience {
     position: string;
+    company?: string;
     location: string;
     startDate: string;
     endDate: string;
     technologies?: string;
-    responsibilities: string;
+    responsibilities?: string;
+    responsibilityList?: string[];
 }


### PR DESCRIPTION
## Summary
- extend the experience DTO to support optional company names and detailed responsibility lists
- refresh the multilingual experience data with company names, aligned bullet points, and updated summaries
- update the experience component layout and styles to render company details and bullet lists cleanly

## Testing
- npm run build *(fails: ng command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2d66c672c832b83c10ee93c787238