### PR TITLE
Update skills data to match CV technology stack

### DIFF
--- a/src/app/data/skills.data.ts
+++ b/src/app/data/skills.data.ts
@@ -10,45 +10,53 @@ export const skills: SkillFull = {
     skills: [
         {
             title: {
-                en: "Languages & Frameworks",
-                it: "Linguaggi & Framework",
-                de: "Sprachen & Frameworks",
-                es: "Lenguajes y Frameworks"
+                en: "Programming Languages",
+                it: "Linguaggi di Programmazione",
+                de: "Programmiersprachen",
+                es: "Lenguajes de Programación"
             },
             skills: [
                 { name: "Java", icon: "https://img.shields.io/badge/java-%23ED8B00.svg?style=for-the-badge&logo=openjdk&logoColor=white", clicked: false },
                 { name: "JavaScript", icon: "https://img.shields.io/badge/javascript-%23323330.svg?style=for-the-badge&logo=javascript&logoColor=%23F7DF1E", clicked: false },
                 { name: "TypeScript", icon: "https://img.shields.io/badge/typescript-%23007ACC.svg?style=for-the-badge&logo=typescript&logoColor=white", clicked: false },
                 { name: "Python", icon: "https://img.shields.io/badge/python-3670A0?style=for-the-badge&logo=python&logoColor=ffdd54", clicked: false },
-                { name: "HTML5", icon: "https://img.shields.io/badge/html5-%23E34F26.svg?style=for-the-badge&logo=html5&logoColor=white", clicked: false }
+                { name: "Bash", icon: "https://img.shields.io/badge/Bash-4EAA25?style=for-the-badge&logo=gnu-bash&logoColor=white", clicked: false }
             ]
         },
         {
             title: {
-                en: "Front-end",
-                it: "Front-end",
-                de: "Front-end",
-                es: "Front-end"
+                en: "Front-end & UI",
+                it: "Front-end & UI",
+                de: "Front-end & UI",
+                es: "Front-end y UI"
             },
             skills: [
                 { name: "Angular", icon: "https://img.shields.io/badge/angular-%23DD0031.svg?style=for-the-badge&logo=angular&logoColor=white", clicked: false },
-                { name: "Bootstrap", icon: "https://img.shields.io/badge/bootstrap-%238511FA.svg?style=for-the-badge&logo=bootstrap&logoColor=white", clicked: false },
+                { name: "AngularJS", icon: "https://img.shields.io/badge/AngularJS-E23237?style=for-the-badge&logo=angularjs&logoColor=white", clicked: false },
                 { name: "React", icon: "https://img.shields.io/badge/react-%2320232a.svg?style=for-the-badge&logo=react&logoColor=%2361DAFB", clicked: false },
+                { name: "Next.js", icon: "https://img.shields.io/badge/Next.js-000000?style=for-the-badge&logo=nextdotjs&logoColor=white", clicked: false },
+                { name: "HTML5", icon: "https://img.shields.io/badge/html5-%23E34F26.svg?style=for-the-badge&logo=html5&logoColor=white", clicked: false },
                 { name: "CSS", icon: "https://img.shields.io/badge/CSS-%231572B6.svg?style=for-the-badge&logo=css3&logoColor=white", clicked: false },
-                { name: "SCSS", icon: "https://img.shields.io/badge/SCSS-hotpink.svg?style=for-the-badge&logo=sass&logoColor=white", clicked: false }
+                { name: "SCSS", icon: "https://img.shields.io/badge/SCSS-hotpink.svg?style=for-the-badge&logo=sass&logoColor=white", clicked: false },
+                { name: "Bootstrap", icon: "https://img.shields.io/badge/bootstrap-%238511FA.svg?style=for-the-badge&logo=bootstrap&logoColor=white", clicked: false }
             ]
         },
         {
             title: {
-                en: "Back-end",
-                it: "Back-end",
-                de: "Back-end",
-                es: "Back-end"
+                en: "Back-end & Services",
+                it: "Back-end & Servizi",
+                de: "Back-end & Services",
+                es: "Back-end y Servicios"
             },
             skills: [
                 { name: "Spring", icon: "https://img.shields.io/badge/spring-%236DB33F.svg?style=for-the-badge&logo=spring&logoColor=white", clicked: false },
+                { name: "Spring Boot", icon: "https://img.shields.io/badge/Spring%20Boot-%236DB33F.svg?style=for-the-badge&logo=springboot&logoColor=white", clicked: false },
                 { name: "Hibernate", icon: "https://img.shields.io/badge/Hibernate-59666C?style=for-the-badge&logo=Hibernate&logoColor=white", clicked: false },
-                { name: "Spring Boot", icon: "https://img.shields.io/badge/Spring%20Boot-%236DB33F.svg?style=for-the-badge&logo=springboot&logoColor=white", clicked: false }
+                { name: ".NET", icon: "https://img.shields.io/badge/.NET-512BD4?style=for-the-badge&logo=dotnet&logoColor=white", clicked: false },
+                { name: "Node.js", icon: "https://img.shields.io/badge/node.js-6DA55F?style=for-the-badge&logo=node.js&logoColor=white", clicked: false },
+                { name: "JavaFX", icon: "https://img.shields.io/badge/JavaFX-3D8E9C?style=for-the-badge&logo=openjdk&logoColor=white", clicked: false },
+                { name: "JSP", icon: "https://img.shields.io/badge/JSP-007396?style=for-the-badge&logo=java&logoColor=white", clicked: false },
+                { name: "JWT", icon: "https://img.shields.io/badge/JWT-000000?style=for-the-badge&logo=JSON%20web%20tokens&logoColor=white", clicked: false }
             ]
         },
         {
@@ -66,40 +74,80 @@ export const skills: SkillFull = {
         },
         {
             title: {
-                en: "Tools & Platforms",
-                it: "Piattaforme e Strumenti",
-                de: "Tools & Plattformen",
-                es: "Herramientas y Plataformas"
+                en: "Cloud & DevOps",
+                it: "Cloud & DevOps",
+                de: "Cloud & DevOps",
+                es: "Cloud y DevOps"
             },
             skills: [
                 { name: "Docker", icon: "https://img.shields.io/badge/docker-%230db7ed.svg?style=for-the-badge&logo=docker&logoColor=white", clicked: false },
                 { name: "Kubernetes", icon: "https://img.shields.io/badge/kubernetes-%23326ce5.svg?style=for-the-badge&logo=kubernetes&logoColor=white", clicked: false },
-                { name: "OpenShift", icon: "https://img.shields.io/badge/OpenShift-EE0000.svg?style=for-the-badge&logo=redhatopenshift&logoColor=white", clicked: false }
+                { name: "OpenShift", icon: "https://img.shields.io/badge/OpenShift-EE0000.svg?style=for-the-badge&logo=redhatopenshift&logoColor=white", clicked: false },
+                { name: "YAML", icon: "https://img.shields.io/badge/YAML-CB171E?style=for-the-badge&logo=yaml&logoColor=white", clicked: false }
             ]
         },
         {
             title: {
-                en: "Versioning",
-                it: "Versionamento",
-                de: "Versionierung",
-                es: "Versionado"
+                en: "Integration & Automation",
+                it: "Integrazioni & Automazione",
+                de: "Integration & Automatisierung",
+                es: "Integraciones y Automatización"
             },
             skills: [
-                { name: "GitHub", icon: "https://img.shields.io/badge/github-%23121011.svg?style=for-the-badge&logo=github&logoColor=white", clicked: false },
-                { name: "GitLab", icon: "https://img.shields.io/badge/gitlab-%23181717.svg?style=for-the-badge&logo=gitlab&logoColor=white", clicked: false },
-                { name: "Bitbucket", icon: "https://img.shields.io/badge/Bitbucket-%230047B3.svg?style=for-the-badge&logo=bitbucket&logoColor=white", clicked: false },
+                { name: "Boomi", icon: "https://img.shields.io/badge/Boomi-1E90FF?style=for-the-badge&logo=boomi&logoColor=white", clicked: false },
+                { name: "Salesforce", icon: "https://img.shields.io/badge/Salesforce-00A1E0?style=for-the-badge&logo=salesforce&logoColor=white", clicked: false },
+                { name: "Elastic", icon: "https://img.shields.io/badge/Elastic-005571?style=for-the-badge&logo=elastic&logoColor=white", clicked: false }
             ]
         },
         {
             title: {
-                en: "Management",
-                it: "Gestione",
-                de: "Management",
-                es: "Gestión"
+                en: "Testing & Documentation",
+                it: "Testing & Documentazione",
+                de: "Testing & Dokumentation",
+                es: "Testing y Documentación"
+            },
+            skills: [
+                { name: "Swagger", icon: "https://img.shields.io/badge/Swagger-85EA2D?style=for-the-badge&logo=swagger&logoColor=black", clicked: false },
+                { name: "Postman", icon: "https://img.shields.io/badge/Postman-FF6C37?style=for-the-badge&logo=postman&logoColor=white", clicked: false }
+            ]
+        },
+        {
+            title: {
+                en: "Build & CI",
+                it: "Build & CI",
+                de: "Build & CI",
+                es: "Build y CI"
+            },
+            skills: [
+                { name: "Gradle", icon: "https://img.shields.io/badge/Gradle-02303A.svg?style=for-the-badge&logo=gradle&logoColor=white", clicked: false },
+                { name: "Apache Maven", icon: "https://img.shields.io/badge/Apache%20Maven-C71A36?style=for-the-badge&logo=apachemaven&logoColor=white", clicked: false }
+            ]
+        },
+        {
+            title: {
+                en: "Version Control",
+                it: "Controllo di Versione",
+                de: "Versionskontrolle",
+                es: "Control de Versiones"
+            },
+            skills: [
+                { name: "Git", icon: "https://img.shields.io/badge/git-%23F05033.svg?style=for-the-badge&logo=git&logoColor=white", clicked: false },
+                { name: "GitHub", icon: "https://img.shields.io/badge/github-%23121011.svg?style=for-the-badge&logo=github&logoColor=white", clicked: false },
+                { name: "GitLab", icon: "https://img.shields.io/badge/gitlab-%23181717.svg?style=for-the-badge&logo=gitlab&logoColor=white", clicked: false },
+                { name: "Bitbucket", icon: "https://img.shields.io/badge/Bitbucket-%230047B3.svg?style=for-the-badge&logo=bitbucket&logoColor=white", clicked: false }
+            ]
+        },
+        {
+            title: {
+                en: "Collaboration & Management",
+                it: "Collaborazione & Gestione",
+                de: "Kollaboration & Management",
+                es: "Colaboración y Gestión"
             },
             skills: [
                 { name: "Trello", icon: "https://img.shields.io/badge/Trello-%23026AA7.svg?style=for-the-badge&logo=Trello&logoColor=white", clicked: false },
                 { name: "Jira", icon: "https://img.shields.io/badge/jira-%230A0FFF.svg?style=for-the-badge&logo=jira&logoColor=white", clicked: false },
+                { name: "Notion", icon: "https://img.shields.io/badge/Notion-000000.svg?style=for-the-badge&logo=notion&logoColor=white", clicked: false }
             ]
         },
         {
@@ -115,25 +163,6 @@ export const skills: SkillFull = {
                 { name: "Windows", icon: "https://img.shields.io/badge/Windows-0078D6?style=for-the-badge&logo=windows&logoColor=white", clicked: false },
                 { name: "Linux", icon: "https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black", clicked: false }
             ]
-        },
-        {
-            title: {
-                en: "Other",
-                it: "Altro",
-                de: "Sonstiges",
-                es: "Otros"
-            },
-            skills: [
-                { name: "Salesforce", icon: "https://img.shields.io/badge/Salesforce-00A1E0?style=for-the-badge&logo=salesforce&logoColor=white", clicked: false },
-                { name: "Elastic", icon: "https://img.shields.io/badge/Elastic-005571?style=for-the-badge&logo=elastic&logoColor=white", clicked: false },
-                { name: "Boomi", icon: "https://img.shields.io/badge/Boomi-1E90FF?style=for-the-badge&logo=boomi&logoColor=white", clicked: false },
-                { name: "Swagger", icon: "https://img.shields.io/badge/Swagger-85EA2D?style=for-the-badge&logo=swagger&logoColor=black", clicked: false },
-                { name: "Postman", icon: "https://img.shields.io/badge/Postman-FF6C37?style=for-the-badge&logo=postman&logoColor=white", clicked: false },
-                { name: "Gradle", icon: "https://img.shields.io/badge/Gradle-02303A.svg?style=for-the-badge&logo=gradle&logoColor=white", clicked: false },
-                { name: "Apache Maven", icon: "https://img.shields.io/badge/Apache%20Maven-C71A36?style=for-the-badge&logo=apachemaven&logoColor=white", clicked: false },
-                { name: "Notion", icon: "https://img.shields.io/badge/Notion-000000.svg?style=for-the-badge&logo=notion&logoColor=white", clicked: false }
-            ]
-
         }
     ]
-}
+};


### PR DESCRIPTION
## Summary
- regroup the skills taxonomy by programming, front-end, back-end, cloud, integrations, testing, build, version control, collaboration, and operating systems
- add missing technologies such as Next.js, AngularJS, Node.js, .NET, Bash, YAML, and integration tools highlighted in the CV
- ensure each skill references the appropriate badge icon and localized category titles remain consistent

## Testing
- no tests were run (not needed for data updates)


------
https://chatgpt.com/codex/tasks/task_e_68e2d66b04f8832b93a337cc017f9bbd