### PR TITLE
Update project cards with CV metadata

### DIFF
--- a/src/app/components/projects/projects.component.html
+++ b/src/app/components/projects/projects.component.html
@@ -11,6 +11,8 @@
                 <div class="project-card">
                     <img class="proj-image" [src]="project.image" alt="Project Image" />
                     <h3>{{ project.title }}</h3>
+                    <p class="project-status">{{ project.status }}</p>
+                    <p class="project-technologies">{{ project.technologies.join(' · ') }}</p>
 
                     <p>
                         {{ getTruncatedDescription(project) }}
@@ -33,6 +35,8 @@
         <div class="project-card" *ngFor="let project of projects.projects">
             <img class="proj-image" [src]="project.image" alt="Project Image" />
             <h3>{{ project.title }}</h3>
+            <p class="project-status">{{ project.status }}</p>
+            <p class="project-technologies">{{ project.technologies.join(' · ') }}</p>
 
             <p>
                 {{ getTruncatedDescription(project) }}

--- a/src/app/components/projects/projects.component.scss
+++ b/src/app/components/projects/projects.component.scss
@@ -41,6 +41,17 @@ section {
         border-radius: 8px 8px 0 0;
     }
 
+    .project-status {
+        font-weight: 600;
+        margin: 0.75em 0 0.35em;
+    }
+
+    .project-technologies {
+        font-size: 0.95em;
+        margin: 0 0 1em;
+        color: #4b5563;
+    }
+
     .more,
     .less {
         cursor: pointer;

--- a/src/app/components/projects/projects.component.ts
+++ b/src/app/components/projects/projects.component.ts
@@ -23,6 +23,8 @@ export class ProjectsComponent implements OnInit {
     projects: [{
       title: "",
       description: "",
+      technologies: [],
+      status: "",
       image: "",
       link: "",
       expanded: false

--- a/src/app/data/projects.data.ts
+++ b/src/app/data/projects.data.ts
@@ -9,21 +9,27 @@ export const projects: ProjectsLangs = {
         projects: [
             {
                 title: 'Micro Games',
-                description: 'A collection of simple games built using various technologies. Key Features: Multiple mini-games designed to challenge players. Interactive UI with responsive design. Easy to extend with new games and features.',
+                status: 'Status: Active · Open source',
+                technologies: ['Angular 16', 'TypeScript', 'RxJS', 'SCSS', 'Node.js'],
+                description: 'Modular suite of casual mini-games with shared core, player profiles and a mobile-ready leaderboard for quick sessions.',
                 image: 'https://github.com/DiegoFCJ/MicroGames/blob/master/overview/loggedPage.png?raw=true',
                 link: 'https://github.com/DiegoFCJ/MicroGames',
                 expanded: false
             },
             {
                 title: 'Self',
-                description: 'This project provides tools for tracking goals and progress, focusing on self-improvement and productivity through an intuitive interface. Users can add plugins for enhanced functionality. Key Features: Goal tracking and visualization, User-friendly task management dashboard, Optimized with modern web technologies.',
+                status: 'Status: Public beta (2024)',
+                technologies: ['Angular 17', 'NestJS', 'PostgreSQL', 'Docker', 'Redis'],
+                description: 'Productivity hub that tracks habits, exposes a plugin marketplace and syncs goals with calendar reminders across devices.',
                 image: 'https://github.com/DiegoFCJ/self/blob/master/self.png?raw=true',
                 link: 'https://github.com/DiegoFCJ/self',
                 expanded: false
             },
             {
                 title: 'E-commerce',
-                description: 'This repository serves as the foundation for an e-commerce application, providing essential features and structure for building a robust online shopping platform.',
+                status: 'Status: In development',
+                technologies: ['Spring Boot 3', 'Angular 17', 'MySQL', 'Keycloak', 'Docker'],
+                description: 'Headless commerce template with modular checkout, inventory workflows and an admin dashboard ready for ERP integrations.',
                 image: 'https://github.com/DiegoFCJ/E-commerce/blob/master/overview/homeSideDash.png?raw=true',
                 link: 'https://github.com/DiegoFCJ/E-commerce',
                 expanded: false
@@ -38,21 +44,27 @@ export const projects: ProjectsLangs = {
         projects: [
             {
                 title: 'Micro Games',
-                description: 'Una raccolta di giochi semplici costruiti utilizzando varie tecnologie. Caratteristiche principali: Molti mini-giochi progettati per sfidare i giocatori. UI interattiva con design reattivo. Facile da estendere con nuovi giochi e funzionalità.',
+                status: 'Stato: Attivo · Open source',
+                technologies: ['Angular 16', 'TypeScript', 'RxJS', 'SCSS', 'Node.js'],
+                description: 'Suite modulare di mini-giochi casual con core condiviso, profili utente e classifica ottimizzata per sessioni rapide su mobile.',
                 image: 'https://github.com/DiegoFCJ/MicroGames/blob/master/overview/loggedPage.png?raw=true',
                 link: 'https://github.com/DiegoFCJ/MicroGames',
                 expanded: false
             },
             {
                 title: 'Self',
-                description: 'Questo progetto fornisce strumenti per monitorare obiettivi e progressi, con un focus sull\'auto-miglioramento e produttività tramite un\'interfaccia intuitiva. Gli utenti possono aggiungere plugin per funzionalità avanzate. Caratteristiche principali: Monitoraggio obiettivi e visualizzazione, Dashboard di gestione attività intuitiva, Ottimizzato con tecnologie web moderne.',
+                status: 'Stato: Beta pubblica (2024)',
+                technologies: ['Angular 17', 'NestJS', 'PostgreSQL', 'Docker', 'Redis'],
+                description: 'Hub di produttività che traccia le abitudini, integra un marketplace di plugin e sincronizza gli obiettivi con promemoria calendario multi-dispositivo.',
                 image: 'https://github.com/DiegoFCJ/self/blob/master/self.png?raw=true',
                 link: 'https://github.com/DiegoFCJ/self',
                 expanded: false
             },
             {
                 title: 'E-commerce',
-                description: 'Questo repository serve come base per un\'applicazione di e-commerce, fornendo funzionalità essenziali e struttura per costruire una piattaforma di shopping online robusta.',
+                status: 'Stato: In sviluppo',
+                technologies: ['Spring Boot 3', 'Angular 17', 'MySQL', 'Keycloak', 'Docker'],
+                description: 'Template headless per e-commerce con checkout modulare, flussi di inventario e dashboard amministrativa pronta per integrazioni ERP.',
                 image: 'https://github.com/DiegoFCJ/E-commerce/blob/master/overview/homeSideDash.png?raw=true',
                 link: 'https://github.com/DiegoFCJ/E-commerce',
                 expanded: false
@@ -67,21 +79,27 @@ export const projects: ProjectsLangs = {
         projects: [
             {
                 title: 'Micro Games',
-                description: 'A collection of simple games built using various technologies.',
+                status: 'Status: Aktiv · Open Source',
+                technologies: ['Angular 16', 'TypeScript', 'RxJS', 'SCSS', 'Node.js'],
+                description: 'Modulare Sammlung von Casual-Minispielen mit gemeinsamem Kern, Spielerprofilen und einer mobiloptimierten Bestenliste.',
                 image: 'https://github.com/DiegoFCJ/MicroGames/blob/master/overview/loggedPage.png?raw=true',
                 link: 'https://github.com/DiegoFCJ/MicroGames',
                 expanded: false
             },
             {
                 title: 'Self',
-                description: 'Tools for tracking goals and progress through an intuitive interface.',
+                status: 'Status: Öffentliche Beta (2024)',
+                technologies: ['Angular 17', 'NestJS', 'PostgreSQL', 'Docker', 'Redis'],
+                description: 'Produktivitätsplattform, die Gewohnheiten erfasst, einen Plugin-Marktplatz integriert und Ziele mit Kalendererinnerungen synchronisiert.',
                 image: 'https://github.com/DiegoFCJ/self/blob/master/self.png?raw=true',
                 link: 'https://github.com/DiegoFCJ/self',
                 expanded: false
             },
             {
                 title: 'E-commerce',
-                description: 'Base repository for building a robust e-commerce platform.',
+                status: 'Status: In Entwicklung',
+                technologies: ['Spring Boot 3', 'Angular 17', 'MySQL', 'Keycloak', 'Docker'],
+                description: 'Headless-Commerce-Vorlage mit modularem Checkout, Bestands-Workflows und einem Admin-Dashboard zur ERP-Integration.',
                 image: 'https://github.com/DiegoFCJ/E-commerce/blob/master/overview/homeSideDash.png?raw=true',
                 link: 'https://github.com/DiegoFCJ/E-commerce',
                 expanded: false
@@ -96,21 +114,27 @@ export const projects: ProjectsLangs = {
         projects: [
             {
                 title: 'Micro Games',
-                description: 'Una colección de juegos sencillos construidos con varias tecnologías.',
+                status: 'Estado: Activo · Código abierto',
+                technologies: ['Angular 16', 'TypeScript', 'RxJS', 'SCSS', 'Node.js'],
+                description: 'Suite modular de minijuegos casuales con núcleo compartido, perfiles de usuario y ranking optimizado para sesiones móviles.',
                 image: 'https://github.com/DiegoFCJ/MicroGames/blob/master/overview/loggedPage.png?raw=true',
                 link: 'https://github.com/DiegoFCJ/MicroGames',
                 expanded: false
             },
             {
                 title: 'Self',
-                description: 'Herramientas para seguir objetivos y progresos con una interfaz intuitiva.',
+                status: 'Estado: Beta pública (2024)',
+                technologies: ['Angular 17', 'NestJS', 'PostgreSQL', 'Docker', 'Redis'],
+                description: 'Centro de productividad que registra hábitos, integra un marketplace de plugins y sincroniza objetivos con recordatorios de calendario.',
                 image: 'https://github.com/DiegoFCJ/self/blob/master/self.png?raw=true',
                 link: 'https://github.com/DiegoFCJ/self',
                 expanded: false
             },
             {
                 title: 'E-commerce',
-                description: 'Repositorio base para una sólida plataforma de compras en línea.',
+                status: 'Estado: En desarrollo',
+                technologies: ['Spring Boot 3', 'Angular 17', 'MySQL', 'Keycloak', 'Docker'],
+                description: 'Plantilla headless de comercio electrónico con checkout modular, flujos de inventario y panel administrativo listo para integrarse con ERP.',
                 image: 'https://github.com/DiegoFCJ/E-commerce/blob/master/overview/homeSideDash.png?raw=true',
                 link: 'https://github.com/DiegoFCJ/E-commerce',
                 expanded: false

--- a/src/app/dtos/ProjectDTO.ts
+++ b/src/app/dtos/ProjectDTO.ts
@@ -17,6 +17,8 @@ export interface ProjectFull {
 export interface Project {
     title: string;
     description: string;
+    technologies: string[];
+    status: string;
     image: string;
     link: string;
     expanded: boolean;

--- a/src/styles/dark.scss
+++ b/src/styles/dark.scss
@@ -49,6 +49,16 @@ body.dark-mode {
         background-color: #202127;
     }
 
+    .project-card {
+        .project-status {
+            color: #c4b5fd;
+        }
+
+        .project-technologies {
+            color: #9ca3af;
+        }
+    }
+
     .full_mask {
         .top-left-circle {
             background-color: #384545;

--- a/src/styles/light.scss
+++ b/src/styles/light.scss
@@ -102,6 +102,10 @@ input[type='checkbox']:checked+.theme-switch-label {
         color: #6c63ff;
     }
 
+    .project-status {
+        color: #4338ca;
+    }
+
     .more,
     .less {
         color: #3b82f6;


### PR DESCRIPTION
## Summary
- update the project data to reflect the CV portfolio items with statuses, technologies and concise descriptions in all languages
- render the new metadata on project cards while keeping carousel and grid behaviour unchanged
- tune light and dark theme styles so the new status and technology details remain legible

## Testing
- npm test -- --watch=false *(fails: ng not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2d66b2cf8832bb1b8abcbc2ade194