### PR TITLE
Refine project card hover border styling

### DIFF
--- a/src/app/components/projects/projects.component.scss
+++ b/src/app/components/projects/projects.component.scss
@@ -23,12 +23,14 @@ section {
     border-radius: 10px;
     text-align: center;
     padding: 1em;
-    transition: transform 0.3s;
+    transition: transform 0.3s, box-shadow 0.3s, border-color 0.3s ease;
+    will-change: transform;
 
     // Hover effect for project card
     &:hover {
-        border: none;
+        border-color: rgba(108, 99, 255, 0.35);
         transform: translateY(-5px);
+        box-shadow: 0 16px 32px rgba(15, 23, 42, 0.18);
         cursor: pointer;
     }
 


### PR DESCRIPTION
## Summary
- adjust the project card hover state to tint the border instead of removing it
- add transform performance hints and a lifted box shadow for the hover effect
- confirm theme SCSS files retain consistent border definitions without hover overrides

## Testing
- npm install *(fails: npm error 403 fetching @angular/compiler-cli)*

------
https://chatgpt.com/codex/tasks/task_e_68e2e1d02ba4832b9427673654285ee1