### PR TITLE
Improve project description toggling

### DIFF
--- a/src/app/components/projects/projects.component.html
+++ b/src/app/components/projects/projects.component.html
@@ -14,13 +14,16 @@
                     <p class="project-status">{{ project.status }}</p>
                     <p class="project-technologies">{{ project.technologies.join(' · ') }}</p>
 
-                    <p>
-                        {{ getTruncatedDescription(project) }}
-                        <span *ngIf="!project.expanded" class="more"
-                            (click)="toggleExpand(project)">{{projects.moreDesc}}</span>
-                        <span *ngIf="project.expanded" class="less"
-                            (click)="toggleExpand(project)">{{projects.lessDesc}}</span>
-                    </p>
+                    <div class="project-description" [class.expanded]="project.expanded" [attr.id]="'project-desc-' + i">
+                        <p>{{ project.description }}</p>
+                    </div>
+                    <button type="button"
+                        class="toggle-description"
+                        (click)="toggleExpand(project)"
+                        [attr.aria-expanded]="project.expanded"
+                        [attr.aria-controls]="'project-desc-' + i">
+                        {{ project.expanded ? projects.lessDesc : projects.moreDesc }}
+                    </button>
 
                     <a class="proj-link" [href]="project.link" target="_blank">{{projects.button}}</a>
                 </div>
@@ -32,18 +35,22 @@
 
     <!-- Griglia per desktop -->
     <div class="project-cards" *ngIf="!isMobile">
-        <div class="project-card" *ngFor="let project of projects.projects">
+        <div class="project-card" *ngFor="let project of projects.projects; let i = index">
             <img class="proj-image" [src]="project.image" alt="Project Image" />
             <h3>{{ project.title }}</h3>
             <p class="project-status">{{ project.status }}</p>
             <p class="project-technologies">{{ project.technologies.join(' · ') }}</p>
 
-            <p>
-                {{ getTruncatedDescription(project) }}
-                <span *ngIf="!project.expanded" class="more"
-                    (click)="toggleExpand(project)">{{projects.moreDesc}}</span>
-                <span *ngIf="project.expanded" class="less" (click)="toggleExpand(project)">{{projects.lessDesc}}</span>
-            </p>
+            <div class="project-description" [class.expanded]="project.expanded" [attr.id]="'project-desc-desktop-' + i">
+                <p>{{ project.description }}</p>
+            </div>
+            <button type="button"
+                class="toggle-description"
+                (click)="toggleExpand(project)"
+                [attr.aria-expanded]="project.expanded"
+                [attr.aria-controls]="'project-desc-desktop-' + i">
+                {{ project.expanded ? projects.lessDesc : projects.moreDesc }}
+            </button>
 
             <a class="proj-link" [href]="project.link" target="_blank">{{projects.button}}</a>
         </div>

--- a/src/app/components/projects/projects.component.scss
+++ b/src/app/components/projects/projects.component.scss
@@ -52,12 +52,43 @@ section {
         color: #4b5563;
     }
 
-    .more,
-    .less {
+    .project-description {
+        margin-bottom: 0.75em;
+        overflow: hidden;
+        display: block;
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 3;
+        max-height: 6.5em;
+        opacity: 0.9;
+        transition: max-height 0.4s ease, opacity 0.4s ease;
+
+        p {
+            margin: 0;
+        }
+
+        &.expanded {
+            -webkit-line-clamp: unset;
+            display: block;
+            max-height: 1000px;
+            opacity: 1;
+            overflow: visible;
+        }
+    }
+
+    .toggle-description {
+        background: none;
+        border: none;
+        color: inherit;
+        font: inherit;
         cursor: pointer;
         text-decoration: underline;
-        display: inline-block;
-        margin-top: 5px;
+        margin-bottom: 1em;
+
+        &:focus-visible {
+            outline: 2px solid currentColor;
+            outline-offset: 2px;
+        }
     }
 
     // Link inside project card
@@ -66,10 +97,6 @@ section {
         font-weight: bold;
         transition: color 0.3s;
     }
-}
-
-.project-card.expanded p {
-    overflow: visible;
 }
 
 /* Mobile responsiveness */

--- a/src/app/components/projects/projects.component.spec.ts
+++ b/src/app/components/projects/projects.component.spec.ts
@@ -1,6 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ProjectsComponent } from './projects.component';
-import { projects } from '../../data/projects.data';
 
 /**
  * Unit tests for ProjectsComponent.
@@ -30,36 +29,52 @@ describe('ProjectsComponent', () => {
   });
 
   /**
-   * Verifies that the description is truncated when it exceeds maxChars.
-   */
-  it('should truncate project description correctly', () => {
-    const longDescription = 'This is a long description '.repeat(10); // A long string
-    const project = { description: longDescription, expanded: false };
-
-    expect(component.getTruncatedDescription(project)).toBe(longDescription.substring(0, component.maxChars) + '...');
-  });
-
-  /**
-   * Verifies that the description is not truncated when it is expanded.
-   */
-  it('should return full description when expanded', () => {
-    const fullDescription = 'This is a full description';
-    const project = { description: fullDescription, expanded: true };
-
-    expect(component.getTruncatedDescription(project)).toBe(fullDescription);
-  });
-
-  /**
    * Verifies that toggleExpand correctly toggles the expanded state of a project.
    */
   it('should toggle expand state correctly', () => {
-    const project = { expanded: false };
+    const project = { expanded: false } as { expanded: boolean };
 
     component.toggleExpand(project);
     expect(project.expanded).toBe(true);
 
     component.toggleExpand(project);
     expect(project.expanded).toBe(false);
+  });
+
+  /**
+   * Verifies that clicking the toggle button updates the DOM state.
+   */
+  it('should update description state in the template when toggled', () => {
+    // Force desktop layout so the grid is rendered for inspection
+    component.isMobile = false;
+    fixture.detectChanges();
+
+    const firstProject = component.projects.projects[0];
+    const card: HTMLElement | null = fixture.nativeElement.querySelector('.project-card');
+    expect(card).withContext('project card should render').not.toBeNull();
+    if (!card) {
+      return;
+    }
+
+    const description = card.querySelector('.project-description');
+    const toggleButton = card.querySelector('.toggle-description') as HTMLButtonElement | null;
+
+    expect(description).withContext('description container should exist').not.toBeNull();
+    expect(toggleButton).withContext('toggle button should exist').not.toBeNull();
+
+    if (!description || !toggleButton) {
+      return;
+    }
+
+    expect(description.classList.contains('expanded')).toBeFalse();
+    expect(toggleButton.getAttribute('aria-expanded')).toBe('false');
+
+    toggleButton.click();
+    fixture.detectChanges();
+
+    expect(firstProject.expanded).toBeTrue();
+    expect(description.classList.contains('expanded')).toBeTrue();
+    expect(toggleButton.getAttribute('aria-expanded')).toBe('true');
   });
 
   /**

--- a/src/app/components/projects/projects.component.ts
+++ b/src/app/components/projects/projects.component.ts
@@ -33,7 +33,6 @@ export class ProjectsComponent implements OnInit {
 
   isMobile = false;
   currentIndex = 0;
-  maxChars = 150;
 
   constructor(
     private translationService: TranslationService,
@@ -63,14 +62,6 @@ export class ProjectsComponent implements OnInit {
 
   toggleExpand(project: any): void {
     project.expanded = !project.expanded;
-  }
-
-  getTruncatedDescription(project: any): string {
-    return project.expanded
-      ? project.description
-      : project.description.length > this.maxChars
-        ? project.description.substring(0, this.maxChars) + '...'
-        : project.description;
   }
 
   moveToNext(): void {


### PR DESCRIPTION
## Summary
- replace string truncation logic with CSS-based clamping driven by the project `expanded` state
- update the project cards to use an accessible button and container that toggles the full description
- add styles for smooth expansion transitions while keeping the carousel and grid layouts responsive

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2e1d09038832bae9b5dcbc3fbaef7