### PR TITLE
Enable autosizing for contact form textarea

### DIFF
--- a/src/app/components/contact-me/contact-me.component.html
+++ b/src/app/components/contact-me/contact-me.component.html
@@ -25,7 +25,8 @@
 
     <mat-form-field appearance="fill" class="form-field">
       <mat-label>{{ contactMe.message }}</mat-label>
-      <textarea matInput id="message" name="message" ngModel required></textarea>
+      <textarea matInput id="message" name="message" ngModel required cdkTextareaAutosize
+        cdkAutosizeMinRows="4" cdkAutosizeMaxRows="12"></textarea>
       <mat-error *ngIf="contactForm.submitted && !contactForm.form.controls['message']?.valid">
         {{ contactMe.messageReq }}
       </mat-error>
@@ -37,5 +38,5 @@
         {{ contactMe.sendBtn }}
       </button>
     </div>
-  </form>
+</form>
 </section>

--- a/src/app/components/contact-me/contact-me.component.ts
+++ b/src/app/components/contact-me/contact-me.component.ts
@@ -7,6 +7,7 @@ import { FormsModule } from '@angular/forms';
 import { MatInputModule } from '@angular/material/input';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatButtonModule } from '@angular/material/button';
+import { TextFieldModule } from '@angular/cdk/text-field';
 import { ContactMe } from '../../dtos/ContactMeDTO';
 import { EmailService } from '../../services/email.service';
 import { TranslationService } from '../../services/translation.service';
@@ -22,6 +23,7 @@ import { TranslationService } from '../../services/translation.service';
     MatInputModule,
     MatFormFieldModule,
     MatButtonModule,
+    TextFieldModule,
   ],
   encapsulation: ViewEncapsulation.None,
   templateUrl: './contact-me.component.html',


### PR DESCRIPTION
## Summary
- import the Angular CDK TextFieldModule into the ContactMe component
- enable textarea autosizing with appropriate minimum and maximum row settings in the contact form template

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2e1d13e98832bb0b56a4e30b610f4