### PR TITLE
Add Discord link to socials data

### DIFF
--- a/src/app/data/socials.data.ts
+++ b/src/app/data/socials.data.ts
@@ -8,5 +8,9 @@ export const socials: Social[] = [
     {
         link: 'https://github.com/DiegoFCJ',
         icon: 'https://cdn.jsdelivr.net/npm/simple-icons@v6/icons/github.svg'
+    },
+    {
+        link: 'https://discord.com/invite/diegofois',
+        icon: 'https://cdn.jsdelivr.net/npm/simple-icons@v6/icons/discord.svg'
     }
 ];


### PR DESCRIPTION
## Summary
- add the Discord profile link and icon to the shared socials data so it appears alongside the other social icons

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2e1d266b0832bb83b45cd10f79874