### PR TITLE
Update StatsComponent unit test expectations

### DIFF
--- a/src/app/components/stats/stats.component.spec.ts
+++ b/src/app/components/stats/stats.component.spec.ts
@@ -52,8 +52,8 @@ describe('StatsComponent', () => {
       projects.en.projects
     );
 
-    expect(stats.hours).toBe('7080+ engineering hours delivered');
-    expect(stats.months).toBe('44+ months across enterprise projects');
+    expect(stats.hours).toBe('7240+ engineering hours delivered');
+    expect(stats.months).toBe('45+ months across enterprise projects');
     expect(stats.projects).toBe('8 end-to-end initiatives led');
     expect(stats.mostUsed).toContain('·');
   });


### PR DESCRIPTION
## Summary
- update the StatsComponent unit test expectations to match the current totals calculated from the data sets

## Testing
- npm run test -- --watch=false *(fails: Angular CLI unavailable because npm install cannot access @angular/compiler-cli package)*

------
https://chatgpt.com/codex/tasks/task_e_68e2e5250834832ba6fc5094570cf3f1