### PR TITLE
Adjust About Me copy to junior tone

### DIFF
--- a/src/app/data/about-me.data.ts
+++ b/src/app/data/about-me.data.ts
@@ -4,29 +4,29 @@ export const aboutMeData: AboutMeLangs = {
     en: {
         title: 'About Me',
         description: `
-      I'm a 29-year-old senior full-stack software developer driven by curiosity and the craft of building reliable products.
-      From Java, Angular and Spring Boot to CI/CD pipelines and Boomi, I design automation-first solutions that streamline processes end-to-end.
-      I thrive in collaborative teams, aligning people and technology to deliver measurable impact.`
+      I'm a 29-year-old junior full-stack software developer who enjoys learning and crafting reliable products with care.
+      From Java, Angular and Spring Boot to CI/CD pipelines and Boomi, I focus on automation-first ideas that steadily improve processes.
+      I enjoy working in collaborative teams, aligning people and technology to deliver meaningful outcomes together.`
     },
     it: {
         title: 'Chi Sono',
         description: `
-      Sono uno sviluppatore software full-stack senior di 29 anni, spinto dalla curiosità e dalla voglia di creare prodotti affidabili.
-      Da Java, Angular e Spring Boot alle pipeline CI/CD e a Boomi, progetto soluzioni orientate all'automazione che ottimizzano i processi a 360 gradi.
-      Lavoro al meglio in team collaborativi, allineando persone e tecnologia per generare impatto concreto.`
+      Sono uno sviluppatore software full-stack junior di 29 anni, mosso dalla curiosità e dal desiderio di creare prodotti affidabili con attenzione.
+      Da Java, Angular e Spring Boot alle pipeline CI/CD e a Boomi, coltivo idee orientate all'automazione che migliorano con costanza i processi.
+      Mi trovo bene nei team collaborativi, allineando persone e tecnologia per ottenere risultati concreti insieme.`
     },
     de: {
         title: 'Über mich',
         description: `
-      Ich bin 29 Jahre alt, arbeite als Senior Full-Stack-Softwareentwickler und liebe es, verlässliche Produkte mit Neugier und Handwerk zu gestalten.
-      Mit Java, Angular, Spring Boot, CI/CD-Pipelines und Boomi entwickle ich Automatisierungslösungen, die Prozesse ganzheitlich verschlanken.
-      In kollaborativen Teams laufe ich zur Höchstform auf, wenn Menschen und Technologie für messbare Ergebnisse zusammenfinden.`
+      Ich bin 29 Jahre alt, arbeite als Junior Full-Stack-Softwareentwickler und freue mich darauf, verlässliche Produkte mit Neugier und Sorgfalt zu gestalten.
+      Mit Java, Angular, Spring Boot, CI/CD-Pipelines und Boomi entwickle ich Automatisierungsideen, die Prozesse Schritt für Schritt verbessern.
+      In kollaborativen Teams arbeite ich besonders gerne, wenn Menschen und Technologie gemeinsam messbare Ergebnisse erreichen.`
     },
     es: {
         title: 'Sobre mí',
         description: `
-      Soy un desarrollador de software full-stack senior de 29 años, impulsado por la curiosidad y el deseo de crear productos fiables.
-      Con Java, Angular, Spring Boot, pipelines de CI/CD y Boomi diseño soluciones centradas en la automatización que optimizan los procesos de principio a fin.
-      Disfruto trabajando en equipos colaborativos, alineando a las personas y la tecnología para lograr un impacto medible.`
+      Soy un desarrollador de software full-stack junior de 29 años, motivado por la curiosidad y el deseo de crear productos fiables con atención.
+      Con Java, Angular, Spring Boot, pipelines de CI/CD y Boomi doy forma a ideas centradas en la automatización que mejoran poco a poco los procesos.
+      Disfruto trabajando en equipos colaborativos, alineando a las personas y la tecnología para conseguir resultados medibles en conjunto.`
     }
 };


### PR DESCRIPTION
## Summary
- update the About Me descriptions across supported languages to reflect a junior role with a softer tone

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e394e71680832ba7c713c63042973c