### PR TITLE
Add Discord social link with improved accessibility

### DIFF
--- a/src/app/components/social/social.component.html
+++ b/src/app/components/social/social.component.html
@@ -1,7 +1,13 @@
 <div class="social-container">
     <div class="social-item" *ngFor="let social of socialsData">
-        <a [href]="social.link" target="_blank" rel="noopener noreferrer">
-            <img [src]="social.icon" alt="social media icon" />
+        <a
+            [href]="social.link"
+            target="_blank"
+            rel="noopener noreferrer"
+            [attr.aria-label]="social.label"
+            [title]="social.label"
+        >
+            <img [src]="social.icon" [alt]="social.label + ' icon'" />
         </a>
     </div>
 </div>

--- a/src/app/data/socials.data.ts
+++ b/src/app/data/socials.data.ts
@@ -3,10 +3,17 @@ import { Social } from '../dtos/SocialDTO';
 export const socials: Social[] = [
     {
         link: 'https://linkedin.com/in/diegofois/',
-        icon: 'https://cdn.jsdelivr.net/npm/simple-icons@v6/icons/linkedin.svg'
+        icon: 'https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/linkedin.svg',
+        label: 'LinkedIn'
     },
     {
         link: 'https://github.com/DiegoFCJ',
-        icon: 'https://cdn.jsdelivr.net/npm/simple-icons@v6/icons/github.svg'
+        icon: 'https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/github.svg',
+        label: 'GitHub'
+    },
+    {
+        link: 'https://discord.com/users/diegofcj',
+        icon: 'https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/discord.svg',
+        label: 'Discord'
     }
 ];

--- a/src/app/dtos/SocialDTO.ts
+++ b/src/app/dtos/SocialDTO.ts
@@ -1,4 +1,5 @@
 export interface Social {
     link: string;
     icon: string;
+    label: string;
 }


### PR DESCRIPTION
## Summary
- add Discord profile metadata to the social links dataset with updated simple-icons assets
- extend social DTO and component template to expose per-network labels for accessibility

## Testing
- npm run test:headless *(fails: sh: 1: Syntax error: "(" unexpected (expecting ")"))*

------
https://chatgpt.com/codex/tasks/task_e_68e394e61e98832b97b42be028c91019