### PR TITLE
Enable autosizing for contact form textarea

### DIFF
--- a/src/app/components/contact-me/contact-me.component.html
+++ b/src/app/components/contact-me/contact-me.component.html
@@ -25,7 +25,7 @@
 
     <mat-form-field appearance="fill" class="form-field">
       <mat-label>{{ contactMe.message }}</mat-label>
-      <textarea matInput id="message" name="message" ngModel required></textarea>
+      <textarea matInput id="message" name="message" ngModel required cdkTextareaAutosize cdkAutosizeMinRows="3" cdkAutosizeMaxRows="10"></textarea>
       <mat-error *ngIf="contactForm.submitted && !contactForm.form.controls['message']?.valid">
         {{ contactMe.messageReq }}
       </mat-error>

--- a/src/app/components/contact-me/contact-me.component.ts
+++ b/src/app/components/contact-me/contact-me.component.ts
@@ -4,6 +4,7 @@ import { CustomPopupComponent } from '../custom-popup/custom-popup.component';
 import { contactMeData } from '../../data/contact-me.data';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { TextFieldModule } from '@angular/cdk/text-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatButtonModule } from '@angular/material/button';
@@ -22,6 +23,7 @@ import { TranslationService } from '../../services/translation.service';
     MatInputModule,
     MatFormFieldModule,
     MatButtonModule,
+    TextFieldModule,
   ],
   encapsulation: ViewEncapsulation.None,
   templateUrl: './contact-me.component.html',


### PR DESCRIPTION
## Summary
- import the Angular CDK text field module into the contact form component
- enable textarea autosizing with reasonable min/max row constraints for the message field

## Testing
- npm run test:headless *(fails: /bin/sh: 1: Syntax error: "(" unexpected)*

------
https://chatgpt.com/codex/tasks/task_e_68e394e7fe24832bb460c7d8412b2cb5