### PR TITLE
Refine project card description toggle

### DIFF
--- a/src/app/components/projects/projects.component.html
+++ b/src/app/components/projects/projects.component.html
@@ -8,19 +8,25 @@
         <div class="carousel-wrapper">
             <div class="carousel-item" *ngFor="let project of projects.projects; let i = index"
                 [class.active]="i === currentIndex">
-                <div class="project-card">
+                <div class="project-card" [class.expanded]="project.expanded">
                     <img class="proj-image" [src]="project.image" alt="Project Image" />
                     <h3>{{ project.title }}</h3>
                     <p class="project-status">{{ project.status }}</p>
                     <p class="project-technologies">{{ project.technologies.join(' · ') }}</p>
 
-                    <p>
-                        {{ getTruncatedDescription(project) }}
-                        <span *ngIf="!project.expanded" class="more"
-                            (click)="toggleExpand(project)">{{projects.moreDesc}}</span>
-                        <span *ngIf="project.expanded" class="less"
-                            (click)="toggleExpand(project)">{{projects.lessDesc}}</span>
-                    </p>
+                    <div class="project-description" [ngClass]="{ 'expanded': project.expanded, 'collapsed': !project.expanded }"
+                        [attr.id]="'project-description-mobile-' + i">
+                        <p>
+                            {{ project.expanded ? project.description : project.description.length > maxChars ?
+                            (project.description | slice: 0:maxChars) + '...' : project.description }}
+                        </p>
+                    </div>
+                    <button type="button" class="toggle-description" (click)="toggleExpand(project)"
+                        [attr.aria-expanded]="project.expanded"
+                        [attr.aria-controls]="'project-description-mobile-' + i"
+                        [attr.aria-label]="(project.expanded ? projects.lessDesc : projects.moreDesc).trim()">
+                        {{ (project.expanded ? projects.lessDesc : projects.moreDesc).trim() }}
+                    </button>
 
                     <a class="proj-link" [href]="project.link" target="_blank">{{projects.button}}</a>
                 </div>
@@ -32,18 +38,25 @@
 
     <!-- Griglia per desktop -->
     <div class="project-cards" *ngIf="!isMobile">
-        <div class="project-card" *ngFor="let project of projects.projects">
+        <div class="project-card" *ngFor="let project of projects.projects; let i = index"
+            [class.expanded]="project.expanded">
             <img class="proj-image" [src]="project.image" alt="Project Image" />
             <h3>{{ project.title }}</h3>
             <p class="project-status">{{ project.status }}</p>
             <p class="project-technologies">{{ project.technologies.join(' · ') }}</p>
 
-            <p>
-                {{ getTruncatedDescription(project) }}
-                <span *ngIf="!project.expanded" class="more"
-                    (click)="toggleExpand(project)">{{projects.moreDesc}}</span>
-                <span *ngIf="project.expanded" class="less" (click)="toggleExpand(project)">{{projects.lessDesc}}</span>
-            </p>
+            <div class="project-description" [ngClass]="{ 'expanded': project.expanded, 'collapsed': !project.expanded }"
+                [attr.id]="'project-description-' + i">
+                <p>
+                    {{ project.expanded ? project.description : project.description.length > maxChars ?
+                    (project.description | slice: 0:maxChars) + '...' : project.description }}
+                </p>
+            </div>
+            <button type="button" class="toggle-description" (click)="toggleExpand(project)"
+                [attr.aria-expanded]="project.expanded" [attr.aria-controls]="'project-description-' + i"
+                [attr.aria-label]="(project.expanded ? projects.lessDesc : projects.moreDesc).trim()">
+                {{ (project.expanded ? projects.lessDesc : projects.moreDesc).trim() }}
+            </button>
 
             <a class="proj-link" [href]="project.link" target="_blank">{{projects.button}}</a>
         </div>

--- a/src/app/components/projects/projects.component.scss
+++ b/src/app/components/projects/projects.component.scss
@@ -15,6 +15,7 @@ section {
     flex-wrap: wrap;
     gap: 1.5em;
     justify-content: center;
+    align-items: stretch;
 }
 
 // Project card styles
@@ -23,12 +24,18 @@ section {
     border-radius: 10px;
     text-align: center;
     padding: 1em;
-    transition: transform 0.3s;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    transform-origin: center top;
+    background-color: var(--project-card-bg, #ffffff);
+    display: flex;
+    flex-direction: column;
+    gap: 0.75em;
 
     // Hover effect for project card
     &:hover {
         border: none;
-        transform: translateY(-5px);
+        transform: scale(1.02);
+        box-shadow: 0 12px 24px rgba(15, 23, 42, 0.15);
         cursor: pointer;
     }
 
@@ -51,25 +58,61 @@ section {
         margin: 0 0 1em;
         color: #4b5563;
     }
+}
 
-    .more,
-    .less {
-        cursor: pointer;
-        text-decoration: underline;
-        display: inline-block;
-        margin-top: 5px;
+.project-description {
+    position: relative;
+    text-align: left;
+    font-size: 0.95em;
+    color: #1f2937;
+
+    p {
+        margin: 0;
     }
 
-    // Link inside project card
-    .proj-link {
-        text-decoration: none;
-        font-weight: bold;
-        transition: color 0.3s;
+    &.collapsed {
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 4;
+        overflow: hidden;
+    }
+
+    &.collapsed::after {
+        content: "";
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        height: 2.5em;
+        background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, var(--project-card-bg, #ffffff) 100%);
+    }
+
+    &.expanded {
+        overflow: visible;
     }
 }
 
-.project-card.expanded p {
-    overflow: visible;
+.toggle-description {
+    align-self: flex-start;
+    border: none;
+    background: none;
+    color: #2563eb;
+    font-weight: 600;
+    cursor: pointer;
+    text-decoration: underline;
+    padding: 0;
+
+    &:focus-visible {
+        outline: 2px solid #1d4ed8;
+        outline-offset: 2px;
+    }
+}
+
+// Link inside project card
+.proj-link {
+    text-decoration: none;
+    font-weight: bold;
+    transition: color 0.3s;
 }
 
 /* Mobile responsiveness */
@@ -83,6 +126,7 @@ section {
         box-shadow: none !important;
         max-width: 100%;
         padding: 1em;
+        gap: 0.75em;
 
         .proj-image {
             width: 100%;

--- a/src/app/components/projects/projects.component.spec.ts
+++ b/src/app/components/projects/projects.component.spec.ts
@@ -30,23 +30,60 @@ describe('ProjectsComponent', () => {
   });
 
   /**
-   * Verifies that the description is truncated when it exceeds maxChars.
+   * Verifies that the description in the template is truncated when it exceeds maxChars.
    */
-  it('should truncate project description correctly', () => {
-    const longDescription = 'This is a long description '.repeat(10); // A long string
-    const project = { description: longDescription, expanded: false };
+  it('should truncate project description correctly in the template', () => {
+    const longDescription = 'This is a long description '.repeat(10);
 
-    expect(component.getTruncatedDescription(project)).toBe(longDescription.substring(0, component.maxChars) + '...');
+    component.maxChars = 50;
+    component.projects = {
+      title: '',
+      button: '',
+      moreDesc: 'Mostra di più',
+      lessDesc: 'Mostra di meno',
+      projects: [{
+        title: 'Test project',
+        description: longDescription,
+        technologies: [],
+        status: '',
+        image: '',
+        link: '',
+        expanded: false
+      }]
+    };
+
+    fixture.detectChanges();
+
+    const descriptionElement: HTMLElement | null = fixture.nativeElement.querySelector('.project-description p');
+    expect(descriptionElement?.textContent?.trim()).toBe(longDescription.slice(0, component.maxChars) + '...');
   });
 
   /**
-   * Verifies that the description is not truncated when it is expanded.
+   * Verifies that the full description is shown when the project is expanded.
    */
-  it('should return full description when expanded', () => {
+  it('should show the full description when expanded', () => {
     const fullDescription = 'This is a full description';
-    const project = { description: fullDescription, expanded: true };
 
-    expect(component.getTruncatedDescription(project)).toBe(fullDescription);
+    component.projects = {
+      title: '',
+      button: '',
+      moreDesc: 'Mostra di più',
+      lessDesc: 'Mostra di meno',
+      projects: [{
+        title: 'Test project',
+        description: fullDescription,
+        technologies: [],
+        status: '',
+        image: '',
+        link: '',
+        expanded: true
+      }]
+    };
+
+    fixture.detectChanges();
+
+    const descriptionElement: HTMLElement | null = fixture.nativeElement.querySelector('.project-description p');
+    expect(descriptionElement?.textContent?.trim()).toBe(fullDescription);
   });
 
   /**

--- a/src/app/components/projects/projects.component.ts
+++ b/src/app/components/projects/projects.component.ts
@@ -65,14 +65,6 @@ export class ProjectsComponent implements OnInit {
     project.expanded = !project.expanded;
   }
 
-  getTruncatedDescription(project: any): string {
-    return project.expanded
-      ? project.description
-      : project.description.length > this.maxChars
-        ? project.description.substring(0, this.maxChars) + '...'
-        : project.description;
-  }
-
   moveToNext(): void {
     this.currentIndex = (this.currentIndex + 1) % this.projects.projects.length;
   }


### PR DESCRIPTION
## Summary
- replace manual description truncation with an accessible description container and ARIA-driven toggle button
- remove the component helper that truncated descriptions and handle shortening inline with the expanded state
- update project card styling with line clamping, gradient fade, stretch alignment, and a scale hover effect that keeps layout stable

## Testing
- npm run build *(fails: ng command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e394e9723c832ba35c262b0e382dc1