### PR TITLE
feat: default to Italian locale

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -2,17 +2,18 @@ import { TestBed } from '@angular/core/testing';
 import { AppComponent } from './app.component';
 import { TranslationService } from './services/translation.service';
 import { BehaviorSubject } from 'rxjs';
+import { LanguageCode } from './models/language-code.type';
 
 describe('AppComponent', () => {
   let mockTranslationService: Partial<TranslationService>;
-  let languageSubject: BehaviorSubject<'en' | 'it' | 'de' | 'es'>;
+  let languageSubject: BehaviorSubject<LanguageCode>;
 
   beforeEach(async () => {
     // Creiamo un BehaviorSubject per simulare il currentLanguage$
-    languageSubject = new BehaviorSubject<'en' | 'it' | 'de' | 'es'>('en');
+    languageSubject = new BehaviorSubject<LanguageCode>('it');
     mockTranslationService = {
       currentLanguage$: languageSubject.asObservable(),
-      setLanguage: jasmine.createSpy('setLanguage').and.callFake((language: 'en' | 'it' | 'de' | 'es') => {
+      setLanguage: jasmine.createSpy('setLanguage').and.callFake((language: LanguageCode) => {
         languageSubject.next(language);
       }),
     };
@@ -29,17 +30,17 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   });
 
-  it('should set the document title to "Diego\'s Portfolio" for English', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    expect(document.title).toEqual("Diego's Portfolio");
-  });
-
   it('should set the document title to "Portfolio di Diego" for Italian', () => {
-    languageSubject.next('it'); // Cambia la lingua simulata in italiano
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     expect(document.title).toEqual('Portfolio di Diego');
+  });
+
+  it('should set the document title to "Diego\'s Portfolio" for English', () => {
+    languageSubject.next('en');
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+    expect(document.title).toEqual("Diego's Portfolio");
   });
 
   it('should set the document title to "Diegos Portfolio" for German', () => {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -24,8 +24,8 @@ export class AppComponent implements OnInit {
     // Cambia il titolo dinamicamente in base alla lingua
     this.translationService.currentLanguage$.subscribe(language => {
       if (isPlatformBrowser(this.platformId)) {
-        let appTitle = APP_TITLE_en;
-        if (language === 'it') appTitle = APP_TITLE_it;
+        let appTitle = APP_TITLE_it;
+        if (language === 'en') appTitle = APP_TITLE_en;
         else if (language === 'de') appTitle = APP_TITLE_de;
         else if (language === 'es') appTitle = APP_TITLE_es;
         document.title = appTitle;

--- a/src/app/components/hero/hero.component.ts
+++ b/src/app/components/hero/hero.component.ts
@@ -22,7 +22,7 @@ import { takeUntil } from 'rxjs/operators';
   styleUrls: ['./hero.component.scss']
 })
 export class HeroComponent implements OnInit, OnDestroy {
-  heroData: HeroFull = heroDataSource.en;
+  heroData: HeroFull = heroDataSource.it ?? heroDataSource.en;
   isLoading = true;
   @Output() navigateNextSection = new EventEmitter<void>();
 
@@ -53,7 +53,7 @@ export class HeroComponent implements OnInit, OnDestroy {
         this.clearTimeOuts();
       });
 
-    this.translationService.getTranslatedData<HeroFull>(heroDataSource)
+    this.translationService.getTranslatedData<HeroFull>(heroDataSource, 'it')
       .pipe(takeUntil(this.destroy$))
       .subscribe(data => {
         this.heroData = data;

--- a/src/app/components/skills/skills.component.spec.ts
+++ b/src/app/components/skills/skills.component.spec.ts
@@ -46,28 +46,28 @@ describe('SkillsComponent', () => {
   });
 
   it('should correctly move to the next section in the carousel', () => {
-    component.sections = skills.skills; // Simulating skills data
+    component.sections = skills.it?.skills ?? skills.en?.skills ?? [];
     component.currentIndex = 0;
     component.moveToNext();
     expect(component.currentIndex).toBe(1); // Should move to the next section
   });
 
   it('should correctly move to the previous section in the carousel', () => {
-    component.sections = skills.skills; // Simulating skills data
+    component.sections = skills.it?.skills ?? skills.en?.skills ?? [];
     component.currentIndex = 1;
     component.moveToPrevious();
     expect(component.currentIndex).toBe(0); // Should move to the previous section
   });
 
   it('should reset to the first section when moving past the last one', () => {
-    component.sections = skills.skills; // Simulating skills data
+    component.sections = skills.it?.skills ?? skills.en?.skills ?? [];
     component.currentIndex = component.sections.length - 1;
     component.moveToNext();
     expect(component.currentIndex).toBe(0); // Should reset to the first section
   });
 
   it('should reset to the last section when moving before the first one', () => {
-    component.sections = skills.skills; // Simulating skills data
+    component.sections = skills.it?.skills ?? skills.en?.skills ?? [];
     component.currentIndex = 0;
     component.moveToPrevious();
     expect(component.currentIndex).toBe(component.sections.length - 1); // Should reset to the last section

--- a/src/app/components/stats/stats.component.spec.ts
+++ b/src/app/components/stats/stats.component.spec.ts
@@ -40,10 +40,10 @@ describe('StatsComponent', () => {
   it('should prepare statistics correctly', () => {
     fixture.detectChanges();
     expect(component.statistics.length).toBe(4);
-    expect(component.statistics[0].label).toBe('Total Hours');
-    expect(component.statistics[1].label).toBe('Experience Months');
-    expect(component.statistics[2].label).toBe('Projects Delivered');
-    expect(component.statistics[3].label).toBe('Core Stack');
+    expect(component.statistics[0].label).toBe('Ore Totali');
+    expect(component.statistics[1].label).toBe('Mesi di Esperienza');
+    expect(component.statistics[2].label).toBe('Progetti Consegnati');
+    expect(component.statistics[3].label).toBe('Stack Principale');
   });
 
   /**
@@ -55,9 +55,9 @@ describe('StatsComponent', () => {
       projects.en.projects
     );
 
-    expect(stats.hours).toBe('7240+ engineering hours delivered');
-    expect(stats.months).toBe('45+ months across enterprise projects');
-    expect(stats.projects).toBe('8 end-to-end initiatives led');
+    expect(stats.hours).toBe('7240+ ore di ingegneria erogate');
+    expect(stats.months).toBe('45+ mesi su progetti enterprise');
+    expect(stats.projects).toBe('8 iniziative end-to-end guidate');
     expect(stats.mostUsed).toContain('·');
   });
 

--- a/src/app/components/stats/stats.component.ts
+++ b/src/app/components/stats/stats.component.ts
@@ -8,6 +8,7 @@ import { projects } from '../../data/projects.data';
 import { TranslationService } from '../../services/translation.service';
 import { Stat, StatsItem } from '../../dtos/StatsDTO';
 import { statsData } from '../../data/stats.data';
+import { LanguageCode } from '../../models/language-code.type';
 
 @Component({
   selector: 'app-stats',
@@ -42,13 +43,26 @@ export class StatsComponent implements OnInit, OnDestroy {
           this.isLoading = true;
         }),
         switchMap(language => {
-          const experiences = experiencesData.en.experiences;
-          const projectList = projects.en.projects;
-          const computed = this.calculateStats(experiences, projectList);
+          const experiencesSource = this.resolveLocalizedContent(experiencesData);
+          const projectsSource = this.resolveLocalizedContent(projects);
+          const statsTemplateSource = this.resolveLocalizedContent(statsData);
+
+          const computed = this.calculateStats(
+            experiencesSource.content.experiences,
+            projectsSource.content.projects
+          );
 
           return forkJoin({
-            template: this.translationService.translateContent(statsData.en, 'en', language),
-            computed: this.translationService.translateContent(computed, 'en', language)
+            template: this.translationService.translateContent(
+              statsTemplateSource.content,
+              statsTemplateSource.language,
+              language
+            ),
+            computed: this.translationService.translateContent(
+              computed,
+              'it',
+              language
+            )
           });
         })
       )
@@ -103,9 +117,9 @@ export class StatsComponent implements OnInit, OnDestroy {
       .map(([tech]) => this.formatTechnology(tech));
 
     return {
-      hours: `${Math.round(totalHours)}+ engineering hours delivered`,
-      months: `${totalMonths}+ months across enterprise projects`,
-      projects: `${totalProjects} end-to-end initiatives led`,
+      hours: `${Math.round(totalHours)}+ ore di ingegneria erogate`,
+      months: `${totalMonths}+ mesi su progetti enterprise`,
+      projects: `${totalProjects} iniziative end-to-end guidate`,
       mostUsed: sortedTechnologies.join(' · ')
     };
   }
@@ -160,5 +174,30 @@ export class StatsComponent implements OnInit, OnDestroy {
       default:
         return '';
     }
+  }
+
+  private resolveLocalizedContent<T extends { [key: string]: any }>(
+    data: Partial<Record<LanguageCode, T>>
+  ): { content: T; language: LanguageCode } {
+    const preferred: LanguageCode = 'it';
+    const preferredContent = data[preferred];
+    if (preferredContent) {
+      return { content: preferredContent, language: preferred };
+    }
+
+    const fallbackOrder: LanguageCode[] = ['en', 'de', 'es'];
+    for (const fallback of fallbackOrder) {
+      const content = data[fallback];
+      if (content) {
+        return { content, language: fallback };
+      }
+    }
+
+    const firstEntry = Object.entries(data)[0];
+    if (firstEntry) {
+      return { content: firstEntry[1] as T, language: firstEntry[0] as LanguageCode };
+    }
+
+    throw new Error('No data available for statistics');
   }
 }

--- a/src/app/data/hero.data.ts
+++ b/src/app/data/hero.data.ts
@@ -1,6 +1,16 @@
 import { HeroFullLangs } from '../dtos/HeroDTO';
 
 export const heroData: HeroFullLangs = {
+    it: {
+        button: 'Scopri di più su di me',
+        description: '',
+        texts: [
+            'Ciao! Mi chiamo Diego Fois',
+            'Benvenuto nel mio portfolio!',
+            'Sono uno sviluppatore software full-stack junior in crescita',
+            'Costruisco esperienze digitali guidate dall\'automazione'
+        ]
+    },
     en: {
         button: 'Learn More About Me',
         description: '',

--- a/src/app/data/skills.data.ts
+++ b/src/app/data/skills.data.ts
@@ -1,108 +1,216 @@
-import { SkillFull } from '../dtos/SkillDTO';
+import { SkillFullLangs } from '../dtos/SkillDTO';
 
-export const skills: SkillFull = {
-    title: 'Tech Stack',
-    skills: [
-        {
-            title: 'Programming Languages',
-            skills: [
-                { name: 'Java', icon: 'https://img.shields.io/badge/java-%23ED8B00.svg?style=for-the-badge&logo=openjdk&logoColor=white', clicked: false },
-                { name: 'JavaScript', icon: 'https://img.shields.io/badge/javascript-%23323330.svg?style=for-the-badge&logo=javascript&logoColor=%23F7DF1E', clicked: false },
-                { name: 'TypeScript', icon: 'https://img.shields.io/badge/typescript-%23007ACC.svg?style=for-the-badge&logo=typescript&logoColor=white', clicked: false },
-                { name: 'Python', icon: 'https://img.shields.io/badge/python-3670A0?style=for-the-badge&logo=python&logoColor=ffdd54', clicked: false },
-                { name: 'Bash', icon: 'https://img.shields.io/badge/Bash-4EAA25?style=for-the-badge&logo=gnu-bash&logoColor=white', clicked: false }
-            ]
-        },
-        {
-            title: 'Front-end & UI',
-            skills: [
-                { name: 'Angular', icon: 'https://img.shields.io/badge/angular-%23DD0031.svg?style=for-the-badge&logo=angular&logoColor=white', clicked: false },
-                { name: 'AngularJS', icon: 'https://img.shields.io/badge/AngularJS-E23237?style=for-the-badge&logo=angularjs&logoColor=white', clicked: false },
-                { name: 'React', icon: 'https://img.shields.io/badge/react-%2320232a.svg?style=for-the-badge&logo=react&logoColor=%2361DAFB', clicked: false },
-                { name: 'Next.js', icon: 'https://img.shields.io/badge/Next.js-000000?style=for-the-badge&logo=nextdotjs&logoColor=white', clicked: false },
-                { name: 'HTML5', icon: 'https://img.shields.io/badge/html5-%23E34F26.svg?style=for-the-badge&logo=html5&logoColor=white', clicked: false },
-                { name: 'CSS', icon: 'https://img.shields.io/badge/CSS-%231572B6.svg?style=for-the-badge&logo=css3&logoColor=white', clicked: false },
-                { name: 'SCSS', icon: 'https://img.shields.io/badge/SCSS-hotpink.svg?style=for-the-badge&logo=sass&logoColor=white', clicked: false },
-                { name: 'Bootstrap', icon: 'https://img.shields.io/badge/bootstrap-%238511FA.svg?style=for-the-badge&logo=bootstrap&logoColor=white', clicked: false }
-            ]
-        },
-        {
-            title: 'Back-end & Services',
-            skills: [
-                { name: 'Spring', icon: 'https://img.shields.io/badge/spring-%236DB33F.svg?style=for-the-badge&logo=spring&logoColor=white', clicked: false },
-                { name: 'Spring Boot', icon: 'https://img.shields.io/badge/Spring%20Boot-%236DB33F.svg?style=for-the-badge&logo=springboot&logoColor=white', clicked: false },
-                { name: 'Hibernate', icon: 'https://img.shields.io/badge/Hibernate-59666C?style=for-the-badge&logo=Hibernate&logoColor=white', clicked: false },
-                { name: '.NET', icon: 'https://img.shields.io/badge/.NET-512BD4?style=for-the-badge&logo=dotnet&logoColor=white', clicked: false },
-                { name: 'Node.js', icon: 'https://img.shields.io/badge/node.js-6DA55F?style=for-the-badge&logo=node.js&logoColor=white', clicked: false },
-                { name: 'JavaFX', icon: 'https://img.shields.io/badge/JavaFX-3D8E9C?style=for-the-badge&logo=openjdk&logoColor=white', clicked: false },
-                { name: 'JSP', icon: 'https://img.shields.io/badge/JSP-007396?style=for-the-badge&logo=java&logoColor=white', clicked: false },
-                { name: 'JWT', icon: 'https://img.shields.io/badge/JWT-000000?style=for-the-badge&logo=JSON%20web%20tokens&logoColor=white', clicked: false }
-            ]
-        },
-        {
-            title: 'Database',
-            skills: [
-                { name: 'MySQL', icon: 'https://img.shields.io/badge/mysql-4479A1.svg?style=for-the-badge&logo=mysql&logoColor=white', clicked: false },
-                { name: 'PostgreSQL', icon: 'https://img.shields.io/badge/postgreSQL-%23316192.svg?style=for-the-badge&logo=postgresql&logoColor=white', clicked: false },
-                { name: 'OracleDB', icon: 'https://img.shields.io/badge/OracleDB-F80000.svg?style=for-the-badge&logo=oracle&logoColor=white', clicked: false }
-            ]
-        },
-        {
-            title: 'Cloud & DevOps',
-            skills: [
-                { name: 'Docker', icon: 'https://img.shields.io/badge/docker-%230db7ed.svg?style=for-the-badge&logo=docker&logoColor=white', clicked: false },
-                { name: 'Kubernetes', icon: 'https://img.shields.io/badge/kubernetes-%23326ce5.svg?style=for-the-badge&logo=kubernetes&logoColor=white', clicked: false },
-                { name: 'OpenShift', icon: 'https://img.shields.io/badge/OpenShift-EE0000.svg?style=for-the-badge&logo=redhatopenshift&logoColor=white', clicked: false },
-                { name: 'YAML', icon: 'https://img.shields.io/badge/YAML-CB171E?style=for-the-badge&logo=yaml&logoColor=white', clicked: false }
-            ]
-        },
-        {
-            title: 'Integration & Automation',
-            skills: [
-                { name: 'Boomi', icon: 'https://img.shields.io/badge/Boomi-1E90FF?style=for-the-badge&logo=boomi&logoColor=white', clicked: false },
-                { name: 'Salesforce', icon: 'https://img.shields.io/badge/Salesforce-00A1E0?style=for-the-badge&logo=salesforce&logoColor=white', clicked: false },
-                { name: 'Elastic', icon: 'https://img.shields.io/badge/Elastic-005571?style=for-the-badge&logo=elastic&logoColor=white', clicked: false }
-            ]
-        },
-        {
-            title: 'Testing & Documentation',
-            skills: [
-                { name: 'Swagger', icon: 'https://img.shields.io/badge/Swagger-85EA2D?style=for-the-badge&logo=swagger&logoColor=black', clicked: false },
-                { name: 'Postman', icon: 'https://img.shields.io/badge/Postman-FF6C37?style=for-the-badge&logo=postman&logoColor=white', clicked: false }
-            ]
-        },
-        {
-            title: 'Build & CI',
-            skills: [
-                { name: 'Gradle', icon: 'https://img.shields.io/badge/Gradle-02303A.svg?style=for-the-badge&logo=gradle&logoColor=white', clicked: false },
-                { name: 'Apache Maven', icon: 'https://img.shields.io/badge/Apache%20Maven-C71A36?style=for-the-badge&logo=apachemaven&logoColor=white', clicked: false }
-            ]
-        },
-        {
-            title: 'Version Control',
-            skills: [
-                { name: 'Git', icon: 'https://img.shields.io/badge/git-%23F05033.svg?style=for-the-badge&logo=git&logoColor=white', clicked: false },
-                { name: 'GitHub', icon: 'https://img.shields.io/badge/github-%23121011.svg?style=for-the-badge&logo=github&logoColor=white', clicked: false },
-                { name: 'GitLab', icon: 'https://img.shields.io/badge/gitlab-%23181717.svg?style=for-the-badge&logo=gitlab&logoColor=white', clicked: false },
-                { name: 'Bitbucket', icon: 'https://img.shields.io/badge/Bitbucket-%230047B3.svg?style=for-the-badge&logo=bitbucket&logoColor=white', clicked: false }
-            ]
-        },
-        {
-            title: 'Collaboration & Management',
-            skills: [
-                { name: 'Trello', icon: 'https://img.shields.io/badge/Trello-%23026AA7.svg?style=for-the-badge&logo=Trello&logoColor=white', clicked: false },
-                { name: 'Jira', icon: 'https://img.shields.io/badge/jira-%230A0FFF.svg?style=for-the-badge&logo=jira&logoColor=white', clicked: false },
-                { name: 'Notion', icon: 'https://img.shields.io/badge/Notion-000000.svg?style=for-the-badge&logo=notion&logoColor=white', clicked: false }
-            ]
-        },
-        {
-            title: 'Operating Systems',
-            skills: [
-                { name: 'Fedora', icon: 'https://img.shields.io/badge/Fedora-294172?style=for-the-badge&logo=fedora&logoColor=white', clicked: false },
-                { name: 'Ubuntu', icon: 'https://img.shields.io/badge/Ubuntu-E95420?style=for-the-badge&logo=ubuntu&logoColor=white', clicked: false },
-                { name: 'Windows', icon: 'https://img.shields.io/badge/Windows-0078D6?style=for-the-badge&logo=windows&logoColor=white', clicked: false },
-                { name: 'Linux', icon: 'https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black', clicked: false }
-            ]
-        }
-    ]
+export const skills: SkillFullLangs = {
+    it: {
+        title: 'Stack Tecnologico',
+        skills: [
+            {
+                title: 'Linguaggi di Programmazione',
+                skills: [
+                    { name: 'Java', icon: 'https://img.shields.io/badge/java-%23ED8B00.svg?style=for-the-badge&logo=openjdk&logoColor=white', clicked: false },
+                    { name: 'JavaScript', icon: 'https://img.shields.io/badge/javascript-%23323330.svg?style=for-the-badge&logo=javascript&logoColor=%23F7DF1E', clicked: false },
+                    { name: 'TypeScript', icon: 'https://img.shields.io/badge/typescript-%23007ACC.svg?style=for-the-badge&logo=typescript&logoColor=white', clicked: false },
+                    { name: 'Python', icon: 'https://img.shields.io/badge/python-3670A0?style=for-the-badge&logo=python&logoColor=ffdd54', clicked: false },
+                    { name: 'Bash', icon: 'https://img.shields.io/badge/Bash-4EAA25?style=for-the-badge&logo=gnu-bash&logoColor=white', clicked: false }
+                ]
+            },
+            {
+                title: 'Front-end e UI',
+                skills: [
+                    { name: 'Angular', icon: 'https://img.shields.io/badge/angular-%23DD0031.svg?style=for-the-badge&logo=angular&logoColor=white', clicked: false },
+                    { name: 'AngularJS', icon: 'https://img.shields.io/badge/AngularJS-E23237?style=for-the-badge&logo=angularjs&logoColor=white', clicked: false },
+                    { name: 'React', icon: 'https://img.shields.io/badge/react-%2320232a.svg?style=for-the-badge&logo=react&logoColor=%2361DAFB', clicked: false },
+                    { name: 'Next.js', icon: 'https://img.shields.io/badge/Next.js-000000?style=for-the-badge&logo=nextdotjs&logoColor=white', clicked: false },
+                    { name: 'HTML5', icon: 'https://img.shields.io/badge/html5-%23E34F26.svg?style=for-the-badge&logo=html5&logoColor=white', clicked: false },
+                    { name: 'CSS', icon: 'https://img.shields.io/badge/CSS-%231572B6.svg?style=for-the-badge&logo=css3&logoColor=white', clicked: false },
+                    { name: 'SCSS', icon: 'https://img.shields.io/badge/SCSS-hotpink.svg?style=for-the-badge&logo=sass&logoColor=white', clicked: false },
+                    { name: 'Bootstrap', icon: 'https://img.shields.io/badge/bootstrap-%238511FA.svg?style=for-the-badge&logo=bootstrap&logoColor=white', clicked: false }
+                ]
+            },
+            {
+                title: 'Back-end e Servizi',
+                skills: [
+                    { name: 'Spring', icon: 'https://img.shields.io/badge/spring-%236DB33F.svg?style=for-the-badge&logo=spring&logoColor=white', clicked: false },
+                    { name: 'Spring Boot', icon: 'https://img.shields.io/badge/Spring%20Boot-%236DB33F.svg?style=for-the-badge&logo=springboot&logoColor=white', clicked: false },
+                    { name: 'Hibernate', icon: 'https://img.shields.io/badge/Hibernate-59666C?style=for-the-badge&logo=Hibernate&logoColor=white', clicked: false },
+                    { name: '.NET', icon: 'https://img.shields.io/badge/.NET-512BD4?style=for-the-badge&logo=dotnet&logoColor=white', clicked: false },
+                    { name: 'Node.js', icon: 'https://img.shields.io/badge/node.js-6DA55F?style=for-the-badge&logo=node.js&logoColor=white', clicked: false },
+                    { name: 'JavaFX', icon: 'https://img.shields.io/badge/JavaFX-3D8E9C?style=for-the-badge&logo=openjdk&logoColor=white', clicked: false },
+                    { name: 'JSP', icon: 'https://img.shields.io/badge/JSP-007396?style=for-the-badge&logo=java&logoColor=white', clicked: false },
+                    { name: 'JWT', icon: 'https://img.shields.io/badge/JWT-000000?style=for-the-badge&logo=JSON%20web%20tokens&logoColor=white', clicked: false }
+                ]
+            },
+            {
+                title: 'Database',
+                skills: [
+                    { name: 'MySQL', icon: 'https://img.shields.io/badge/mysql-4479A1.svg?style=for-the-badge&logo=mysql&logoColor=white', clicked: false },
+                    { name: 'PostgreSQL', icon: 'https://img.shields.io/badge/postgreSQL-%23316192.svg?style=for-the-badge&logo=postgresql&logoColor=white', clicked: false },
+                    { name: 'OracleDB', icon: 'https://img.shields.io/badge/OracleDB-F80000.svg?style=for-the-badge&logo=oracle&logoColor=white', clicked: false }
+                ]
+            },
+            {
+                title: 'Cloud e DevOps',
+                skills: [
+                    { name: 'Docker', icon: 'https://img.shields.io/badge/docker-%230db7ed.svg?style=for-the-badge&logo=docker&logoColor=white', clicked: false },
+                    { name: 'Kubernetes', icon: 'https://img.shields.io/badge/kubernetes-%23326ce5.svg?style=for-the-badge&logo=kubernetes&logoColor=white', clicked: false },
+                    { name: 'OpenShift', icon: 'https://img.shields.io/badge/OpenShift-EE0000.svg?style=for-the-badge&logo=redhatopenshift&logoColor=white', clicked: false },
+                    { name: 'YAML', icon: 'https://img.shields.io/badge/YAML-CB171E?style=for-the-badge&logo=yaml&logoColor=white', clicked: false }
+                ]
+            },
+            {
+                title: 'Integrazione e Automazione',
+                skills: [
+                    { name: 'Boomi', icon: 'https://img.shields.io/badge/Boomi-1E90FF?style=for-the-badge&logo=boomi&logoColor=white', clicked: false },
+                    { name: 'Salesforce', icon: 'https://img.shields.io/badge/Salesforce-00A1E0?style=for-the-badge&logo=salesforce&logoColor=white', clicked: false },
+                    { name: 'Elastic', icon: 'https://img.shields.io/badge/Elastic-005571?style=for-the-badge&logo=elastic&logoColor=white', clicked: false }
+                ]
+            },
+            {
+                title: 'Testing e Documentazione',
+                skills: [
+                    { name: 'Swagger', icon: 'https://img.shields.io/badge/Swagger-85EA2D?style=for-the-badge&logo=swagger&logoColor=black', clicked: false },
+                    { name: 'Postman', icon: 'https://img.shields.io/badge/Postman-FF6C37?style=for-the-badge&logo=postman&logoColor=white', clicked: false }
+                ]
+            },
+            {
+                title: 'Build e CI',
+                skills: [
+                    { name: 'Gradle', icon: 'https://img.shields.io/badge/Gradle-02303A.svg?style=for-the-badge&logo=gradle&logoColor=white', clicked: false },
+                    { name: 'Apache Maven', icon: 'https://img.shields.io/badge/Apache%20Maven-C71A36?style=for-the-badge&logo=apachemaven&logoColor=white', clicked: false }
+                ]
+            },
+            {
+                title: 'Version Control',
+                skills: [
+                    { name: 'Git', icon: 'https://img.shields.io/badge/git-%23F05033.svg?style=for-the-badge&logo=git&logoColor=white', clicked: false },
+                    { name: 'GitHub', icon: 'https://img.shields.io/badge/github-%23121011.svg?style=for-the-badge&logo=github&logoColor=white', clicked: false },
+                    { name: 'GitLab', icon: 'https://img.shields.io/badge/gitlab-%23181717.svg?style=for-the-badge&logo=gitlab&logoColor=white', clicked: false },
+                    { name: 'Bitbucket', icon: 'https://img.shields.io/badge/Bitbucket-%230047B3.svg?style=for-the-badge&logo=bitbucket&logoColor=white', clicked: false }
+                ]
+            },
+            {
+                title: 'Collaborazione e Management',
+                skills: [
+                    { name: 'Trello', icon: 'https://img.shields.io/badge/Trello-%23026AA7.svg?style=for-the-badge&logo=Trello&logoColor=white', clicked: false },
+                    { name: 'Jira', icon: 'https://img.shields.io/badge/jira-%230A0FFF.svg?style=for-the-badge&logo=jira&logoColor=white', clicked: false },
+                    { name: 'Notion', icon: 'https://img.shields.io/badge/Notion-000000.svg?style=for-the-badge&logo=notion&logoColor=white', clicked: false }
+                ]
+            },
+            {
+                title: 'Sistemi Operativi',
+                skills: [
+                    { name: 'Fedora', icon: 'https://img.shields.io/badge/Fedora-294172?style=for-the-badge&logo=fedora&logoColor=white', clicked: false },
+                    { name: 'Ubuntu', icon: 'https://img.shields.io/badge/Ubuntu-E95420?style=for-the-badge&logo=ubuntu&logoColor=white', clicked: false },
+                    { name: 'Windows', icon: 'https://img.shields.io/badge/Windows-0078D6?style=for-the-badge&logo=windows&logoColor=white', clicked: false },
+                    { name: 'Linux', icon: 'https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black', clicked: false }
+                ]
+            }
+        ]
+    },
+    en: {
+        title: 'Tech Stack',
+        skills: [
+            {
+                title: 'Programming Languages',
+                skills: [
+                    { name: 'Java', icon: 'https://img.shields.io/badge/java-%23ED8B00.svg?style=for-the-badge&logo=openjdk&logoColor=white', clicked: false },
+                    { name: 'JavaScript', icon: 'https://img.shields.io/badge/javascript-%23323330.svg?style=for-the-badge&logo=javascript&logoColor=%23F7DF1E', clicked: false },
+                    { name: 'TypeScript', icon: 'https://img.shields.io/badge/typescript-%23007ACC.svg?style=for-the-badge&logo=typescript&logoColor=white', clicked: false },
+                    { name: 'Python', icon: 'https://img.shields.io/badge/python-3670A0?style=for-the-badge&logo=python&logoColor=ffdd54', clicked: false },
+                    { name: 'Bash', icon: 'https://img.shields.io/badge/Bash-4EAA25?style=for-the-badge&logo=gnu-bash&logoColor=white', clicked: false }
+                ]
+            },
+            {
+                title: 'Front-end & UI',
+                skills: [
+                    { name: 'Angular', icon: 'https://img.shields.io/badge/angular-%23DD0031.svg?style=for-the-badge&logo=angular&logoColor=white', clicked: false },
+                    { name: 'AngularJS', icon: 'https://img.shields.io/badge/AngularJS-E23237?style=for-the-badge&logo=angularjs&logoColor=white', clicked: false },
+                    { name: 'React', icon: 'https://img.shields.io/badge/react-%2320232a.svg?style=for-the-badge&logo=react&logoColor=%2361DAFB', clicked: false },
+                    { name: 'Next.js', icon: 'https://img.shields.io/badge/Next.js-000000?style=for-the-badge&logo=nextdotjs&logoColor=white', clicked: false },
+                    { name: 'HTML5', icon: 'https://img.shields.io/badge/html5-%23E34F26.svg?style=for-the-badge&logo=html5&logoColor=white', clicked: false },
+                    { name: 'CSS', icon: 'https://img.shields.io/badge/CSS-%231572B6.svg?style=for-the-badge&logo=css3&logoColor=white', clicked: false },
+                    { name: 'SCSS', icon: 'https://img.shields.io/badge/SCSS-hotpink.svg?style=for-the-badge&logo=sass&logoColor=white', clicked: false },
+                    { name: 'Bootstrap', icon: 'https://img.shields.io/badge/bootstrap-%238511FA.svg?style=for-the-badge&logo=bootstrap&logoColor=white', clicked: false }
+                ]
+            },
+            {
+                title: 'Back-end & Services',
+                skills: [
+                    { name: 'Spring', icon: 'https://img.shields.io/badge/spring-%236DB33F.svg?style=for-the-badge&logo=spring&logoColor=white', clicked: false },
+                    { name: 'Spring Boot', icon: 'https://img.shields.io/badge/Spring%20Boot-%236DB33F.svg?style=for-the-badge&logo=springboot&logoColor=white', clicked: false },
+                    { name: 'Hibernate', icon: 'https://img.shields.io/badge/Hibernate-59666C?style=for-the-badge&logo=Hibernate&logoColor=white', clicked: false },
+                    { name: '.NET', icon: 'https://img.shields.io/badge/.NET-512BD4?style=for-the-badge&logo=dotnet&logoColor=white', clicked: false },
+                    { name: 'Node.js', icon: 'https://img.shields.io/badge/node.js-6DA55F?style=for-the-badge&logo=node.js&logoColor=white', clicked: false },
+                    { name: 'JavaFX', icon: 'https://img.shields.io/badge/JavaFX-3D8E9C?style=for-the-badge&logo=openjdk&logoColor=white', clicked: false },
+                    { name: 'JSP', icon: 'https://img.shields.io/badge/JSP-007396?style=for-the-badge&logo=java&logoColor=white', clicked: false },
+                    { name: 'JWT', icon: 'https://img.shields.io/badge/JWT-000000?style=for-the-badge&logo=JSON%20web%20tokens&logoColor=white', clicked: false }
+                ]
+            },
+            {
+                title: 'Database',
+                skills: [
+                    { name: 'MySQL', icon: 'https://img.shields.io/badge/mysql-4479A1.svg?style=for-the-badge&logo=mysql&logoColor=white', clicked: false },
+                    { name: 'PostgreSQL', icon: 'https://img.shields.io/badge/postgreSQL-%23316192.svg?style=for-the-badge&logo=postgresql&logoColor=white', clicked: false },
+                    { name: 'OracleDB', icon: 'https://img.shields.io/badge/OracleDB-F80000.svg?style=for-the-badge&logo=oracle&logoColor=white', clicked: false }
+                ]
+            },
+            {
+                title: 'Cloud & DevOps',
+                skills: [
+                    { name: 'Docker', icon: 'https://img.shields.io/badge/docker-%230db7ed.svg?style=for-the-badge&logo=docker&logoColor=white', clicked: false },
+                    { name: 'Kubernetes', icon: 'https://img.shields.io/badge/kubernetes-%23326ce5.svg?style=for-the-badge&logo=kubernetes&logoColor=white', clicked: false },
+                    { name: 'OpenShift', icon: 'https://img.shields.io/badge/OpenShift-EE0000.svg?style=for-the-badge&logo=redhatopenshift&logoColor=white', clicked: false },
+                    { name: 'YAML', icon: 'https://img.shields.io/badge/YAML-CB171E?style=for-the-badge&logo=yaml&logoColor=white', clicked: false }
+                ]
+            },
+            {
+                title: 'Integration & Automation',
+                skills: [
+                    { name: 'Boomi', icon: 'https://img.shields.io/badge/Boomi-1E90FF?style=for-the-badge&logo=boomi&logoColor=white', clicked: false },
+                    { name: 'Salesforce', icon: 'https://img.shields.io/badge/Salesforce-00A1E0?style=for-the-badge&logo=salesforce&logoColor=white', clicked: false },
+                    { name: 'Elastic', icon: 'https://img.shields.io/badge/Elastic-005571?style=for-the-badge&logo=elastic&logoColor=white', clicked: false }
+                ]
+            },
+            {
+                title: 'Testing & Documentation',
+                skills: [
+                    { name: 'Swagger', icon: 'https://img.shields.io/badge/Swagger-85EA2D?style=for-the-badge&logo=swagger&logoColor=black', clicked: false },
+                    { name: 'Postman', icon: 'https://img.shields.io/badge/Postman-FF6C37?style=for-the-badge&logo=postman&logoColor=white', clicked: false }
+                ]
+            },
+            {
+                title: 'Build & CI',
+                skills: [
+                    { name: 'Gradle', icon: 'https://img.shields.io/badge/Gradle-02303A.svg?style=for-the-badge&logo=gradle&logoColor=white', clicked: false },
+                    { name: 'Apache Maven', icon: 'https://img.shields.io/badge/Apache%20Maven-C71A36?style=for-the-badge&logo=apachemaven&logoColor=white', clicked: false }
+                ]
+            },
+            {
+                title: 'Version Control',
+                skills: [
+                    { name: 'Git', icon: 'https://img.shields.io/badge/git-%23F05033.svg?style=for-the-badge&logo=git&logoColor=white', clicked: false },
+                    { name: 'GitHub', icon: 'https://img.shields.io/badge/github-%23121011.svg?style=for-the-badge&logo=github&logoColor=white', clicked: false },
+                    { name: 'GitLab', icon: 'https://img.shields.io/badge/gitlab-%23181717.svg?style=for-the-badge&logo=gitlab&logoColor=white', clicked: false },
+                    { name: 'Bitbucket', icon: 'https://img.shields.io/badge/Bitbucket-%230047B3.svg?style=for-the-badge&logo=bitbucket&logoColor=white', clicked: false }
+                ]
+            },
+            {
+                title: 'Collaboration & Management',
+                skills: [
+                    { name: 'Trello', icon: 'https://img.shields.io/badge/Trello-%23026AA7.svg?style=for-the-badge&logo=Trello&logoColor=white', clicked: false },
+                    { name: 'Jira', icon: 'https://img.shields.io/badge/jira-%230A0FFF.svg?style=for-the-badge&logo=jira&logoColor=white', clicked: false },
+                    { name: 'Notion', icon: 'https://img.shields.io/badge/Notion-000000.svg?style=for-the-badge&logo=notion&logoColor=white', clicked: false }
+                ]
+            },
+            {
+                title: 'Operating Systems',
+                skills: [
+                    { name: 'Fedora', icon: 'https://img.shields.io/badge/Fedora-294172?style=for-the-badge&logo=fedora&logoColor=white', clicked: false },
+                    { name: 'Ubuntu', icon: 'https://img.shields.io/badge/Ubuntu-E95420?style=for-the-badge&logo=ubuntu&logoColor=white', clicked: false },
+                    { name: 'Windows', icon: 'https://img.shields.io/badge/Windows-0078D6?style=for-the-badge&logo=windows&logoColor=white', clicked: false },
+                    { name: 'Linux', icon: 'https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black', clicked: false }
+                ]
+            }
+        ]
+    }
 };

--- a/src/app/data/stats.data.ts
+++ b/src/app/data/stats.data.ts
@@ -1,6 +1,15 @@
 import { Stats } from "../dtos/StatsDTO";
 
 export const statsData: Stats = {
+    it: {
+        title: 'Statistiche',
+        stats: [
+            { icon: 'schedule', label: 'Ore Totali', value: 'Oltre 7K ore di ingegneria' },
+            { icon: 'today', label: 'Mesi di Esperienza', value: 'Oltre 44 mesi di valore progettuale' },
+            { icon: 'work', label: 'Progetti Consegnati', value: '8 iniziative end-to-end' },
+            { icon: 'code', label: 'Stack Principale', value: 'Spring Boot · Java · Angular · SQL Server' },
+        ]
+    },
     en: {
         title: 'Statistics',
         stats: [

--- a/src/app/dtos/SkillDTO.ts
+++ b/src/app/dtos/SkillDTO.ts
@@ -1,3 +1,5 @@
+import { LanguageCode } from '../models/language-code.type';
+
 export interface SkillFull {
     title: string;
     skills: SkillSection[];
@@ -13,4 +15,6 @@ export interface SkillItem {
     icon: string;
     clicked: boolean;
 }
+
+export type SkillFullLangs = Partial<Record<LanguageCode, SkillFull>>;
 

--- a/src/app/models/language-code.type.ts
+++ b/src/app/models/language-code.type.ts
@@ -1,0 +1,1 @@
+export type LanguageCode = 'en' | 'it' | 'de' | 'es';

--- a/src/app/services/translation.service.spec.ts
+++ b/src/app/services/translation.service.spec.ts
@@ -23,7 +23,7 @@ describe('TranslationService', () => {
 
     internals.cache?.clear();
     internals.storage?.removeItem('translation-cache');
-    service.setLanguage('en');
+    service.setLanguage('it');
   });
 
   afterEach(() => {
@@ -34,9 +34,9 @@ describe('TranslationService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should have "en" as the default language', async () => {
+  it('should have "it" as the default language', async () => {
     const language = await firstValueFrom(service.currentLanguage$);
-    expect(language).toBe('en');
+    expect(language).toBe('it');
   });
 
   it('should update the language when setLanguage is called', () => {

--- a/src/index.html
+++ b/src/index.html
@@ -1,9 +1,9 @@
 <!doctype html>
-<html lang="en">
+<html lang="it">
 
 <head>
   <meta charset="utf-8">
-  <title>Diego's Portfolio</title>
+  <title>Portfolio di Diego</title>
   <base href="./">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">


### PR DESCRIPTION
## Summary
- switch the translation service and supporting mocks to default to Italian while preserving cache persistence and fallback logic
- add Italian source content and fallback selection in hero, skills, and stats flows, updating specs to reflect the new baseline
- refresh the shell document and app title handling to use Italian defaults

## Testing
- npm test *(fails: Angular CLI missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3c9a79ec4832ba867d43d492d1516