### PR TITLE
Refresh about section content and design

### DIFF
--- a/src/app/components/about/about.component.html
+++ b/src/app/components/about/about.component.html
@@ -1,11 +1,41 @@
 <section class="about-section">
-  <div class="about-content" *ngIf="!isLoading; else loadingTemplate">
-    <h2 class="about-title">{{ aboutMe.title }}</h2>
-    <p class="about-description">{{ aboutMe.description }}</p>
+  <div class="about-container" [class.is-loading]="isLoading">
+    <h2 class="about-title">
+      <ng-container *ngIf="!isLoading && aboutMe.title; else titleSkeleton">
+        {{ aboutMe.title }}
+      </ng-container>
+    </h2>
+
+    <ng-container *ngIf="!isLoading; else loadingBody">
+      <div class="about-body">
+        <p
+          class="about-paragraph"
+          *ngFor="let paragraph of aboutMe.paragraphs"
+        >
+          {{ paragraph }}
+        </p>
+
+        <section class="about-highlights" *ngIf="aboutMe.highlights?.length">
+          <h3 class="about-subtitle">{{ aboutMe.highlightsTitle }}</h3>
+          <ul class="about-list">
+            <li class="about-list-item" *ngFor="let highlight of aboutMe.highlights">
+              {{ highlight }}
+            </li>
+          </ul>
+        </section>
+      </div>
+    </ng-container>
   </div>
-  <ng-template #loadingTemplate>
-    <div class="about-content">
-      <h2 class="about-title">{{ aboutMe.title }}</h2>
+
+  <ng-template #titleSkeleton>
+    <span class="about-skeleton about-skeleton__title" aria-hidden="true"></span>
+  </ng-template>
+
+  <ng-template #loadingBody>
+    <div class="about-body about-body--loading" aria-hidden="true">
+      <div class="about-skeleton about-skeleton__paragraph" *ngFor="let placeholder of placeholders"></div>
+      <div class="about-skeleton about-skeleton__subtitle"></div>
+      <div class="about-skeleton about-skeleton__list" *ngFor="let item of placeholders"></div>
     </div>
   </ng-template>
 </section>

--- a/src/app/components/about/about.component.scss
+++ b/src/app/components/about/about.component.scss
@@ -1,38 +1,170 @@
+:host {
+    --about-accent: #6366f1;
+    --about-accent-soft: rgba(99, 102, 241, 0.18);
+    --about-card-bg: rgba(15, 23, 42, 0.06);
+    --about-card-border: rgba(99, 102, 241, 0.22);
+    --about-text-muted: rgba(15, 23, 42, 0.7);
+}
 
 .about-section {
     position: relative;
     z-index: 6;
     min-height: 100vh;
     display: flex;
-    flex-direction: column;
     justify-content: center;
     align-items: center;
-    margin-top: 0;
-    margin-bottom: 0;
+    padding: clamp(2.5rem, 6vw, 5rem) clamp(1.25rem, 5vw, 4rem);
+    background: linear-gradient(160deg, rgba(99, 102, 241, 0.08), rgba(79, 70, 229, 0));
 }
 
-.about-content {
+.about-container {
+    width: min(80vw, 960px);
+    margin: 0 auto;
+    background: linear-gradient(135deg, var(--about-card-bg), rgba(99, 102, 241, 0.14));
+    border: 1px solid var(--about-card-border);
+    border-radius: 24px;
+    padding: clamp(2rem, 5vw, 3rem);
+    box-shadow: 0 24px 55px rgba(15, 23, 42, 0.12);
+    backdrop-filter: blur(10px);
     display: flex;
     flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    width: 50vw;
-    max-width: 600px;
+    gap: clamp(1.5rem, 3vw, 2.25rem);
+    transition: transform 250ms ease, box-shadow 250ms ease;
 }
 
-.about-description {
-    max-width: 90%;
+.about-container.is-loading {
+    transform: none;
+    box-shadow: 0 20px 45px rgba(15, 23, 42, 0.1);
+    pointer-events: none;
 }
 
-@media (max-width: 768px) {
-    .about-content {
-        width: 80vw;
-        max-width: 90%;
+.about-container:not(.is-loading):hover {
+    transform: translateY(-6px);
+    box-shadow: 0 32px 65px rgba(15, 23, 42, 0.16);
+}
+
+.about-title {
+    margin: 0;
+    font-size: clamp(1.8rem, 3.5vw, 2.6rem);
+    font-weight: 700;
+    text-align: center;
+}
+
+.about-body {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1rem, 2.5vw, 1.75rem);
+    color: rgba(15, 23, 42, 0.9);
+    line-height: 1.65;
+}
+
+.about-paragraph {
+    margin: 0;
+    font-size: clamp(1rem, 2.2vw, 1.125rem);
+}
+
+.about-highlights {
+    padding: clamp(1rem, 2vw, 1.5rem);
+    border-radius: 18px;
+    background: rgba(99, 102, 241, 0.08);
+    border: 1px solid rgba(99, 102, 241, 0.25);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.about-subtitle {
+    margin: 0 0 0.75rem;
+    font-size: clamp(1.1rem, 2.5vw, 1.3rem);
+    font-weight: 600;
+    color: var(--about-text-muted);
+}
+
+.about-list {
+    margin: 0;
+    padding-left: 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.about-list-item {
+    font-size: clamp(0.95rem, 2vw, 1.1rem);
+    position: relative;
+}
+
+.about-body--loading {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(0.75rem, 2vw, 1.25rem);
+}
+
+.about-skeleton {
+    display: block;
+    width: 100%;
+    border-radius: 12px;
+    background: linear-gradient(90deg, rgba(148, 163, 184, 0.12), rgba(148, 163, 184, 0.26), rgba(148, 163, 184, 0.12));
+    background-size: 200% 100%;
+    animation: shimmer 1.5s ease-in-out infinite;
+}
+
+.about-skeleton__title {
+    height: 1.6rem;
+    margin: 0 auto;
+    width: clamp(12rem, 40%, 18rem);
+}
+
+.about-skeleton__paragraph {
+    height: 1.1rem;
+}
+
+.about-skeleton__subtitle {
+    height: 1.2rem;
+    width: clamp(10rem, 35%, 14rem);
+}
+
+.about-skeleton__list {
+    height: 0.95rem;
+    width: clamp(14rem, 75%, 20rem);
+}
+
+@keyframes shimmer {
+    0% {
+        background-position: 200% 0;
+    }
+    100% {
+        background-position: -200% 0;
     }
 }
 
-@media (max-width: 480px) {
-    .about-content {
-        width: 90vw;
+@media (max-width: 992px) {
+    .about-container {
+        width: min(85vw, 720px);
+    }
+}
+
+@media (max-width: 768px) {
+    .about-section {
+        padding: clamp(2rem, 8vw, 3rem) clamp(1rem, 6vw, 2.5rem);
+    }
+
+    .about-container {
+        width: min(92vw, 640px);
+        padding: clamp(1.75rem, 6vw, 2.5rem);
+        border-radius: 20px;
+    }
+
+    .about-highlights {
+        padding: clamp(0.85rem, 5vw, 1.25rem);
+    }
+}
+
+@media (max-width: 540px) {
+    .about-container {
+        width: min(96vw, 520px);
+        padding: clamp(1.5rem, 7vw, 2rem);
+        border-radius: 18px;
+    }
+
+    .about-list {
+        padding-left: 1rem;
     }
 }

--- a/src/app/components/about/about.component.scss
+++ b/src/app/components/about/about.component.scss
@@ -50,17 +50,21 @@
     text-align: center;
 }
 
+
 .about-body {
     display: flex;
     flex-direction: column;
     gap: clamp(1rem, 2.5vw, 1.75rem);
     color: rgba(15, 23, 42, 0.9);
     line-height: 1.65;
+    align-items: center;
+    text-align: center;
 }
 
 .about-paragraph {
     margin: 0;
     font-size: clamp(1rem, 2.2vw, 1.125rem);
+    width: 100%;
 }
 
 .about-highlights {
@@ -69,6 +73,8 @@
     background: rgba(99, 102, 241, 0.08);
     border: 1px solid rgba(99, 102, 241, 0.25);
     box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+    align-self: stretch;
+    text-align: left;
 }
 
 .about-subtitle {
@@ -84,11 +90,13 @@
     display: flex;
     flex-direction: column;
     gap: 0.75rem;
+    text-align: left;
 }
 
 .about-list-item {
     font-size: clamp(0.95rem, 2vw, 1.1rem);
     position: relative;
+    text-align: left;
 }
 
 .about-body--loading {

--- a/src/app/components/about/about.component.spec.ts
+++ b/src/app/components/about/about.component.spec.ts
@@ -37,23 +37,33 @@ describe('AboutComponent', () => {
   /**
    * Verifies that the aboutMe property is initialized correctly.
    */
-  it('should initialize aboutMe correctly', () => {
+  it('should initialize aboutMe correctly', async () => {
+    await fixture.whenStable();
+    fixture.detectChanges();
+
     expect(component.aboutMe).toBeDefined();
     expect(component.aboutMe.title).toBeTruthy();
-    expect(component.aboutMe.description).toBeTruthy();
+    expect(component.aboutMe.paragraphs.length).toBeGreaterThan(0);
+    expect(component.aboutMe.highlightsTitle).toBeTruthy();
+    expect(component.aboutMe.highlights.length).toBeGreaterThan(0);
   });
 
   /**
-   * Verifies that the template renders title and description correctly.
+   * Verifies that the template renders title, paragraphs and highlights correctly.
    */
-  it('should render title and description in the template', () => {
+  it('should render title and structured content in the template', async () => {
+    await fixture.whenStable();
+    fixture.detectChanges();
+
     const compiled = fixture.nativeElement as HTMLElement;
 
     const titleElement = compiled.querySelector('.about-title') as HTMLElement;
-    const descriptionElement = compiled.querySelector('.about-description') as HTMLElement;
+    const paragraphElements = compiled.querySelectorAll('.about-paragraph');
+    const highlightItems = compiled.querySelectorAll('.about-list-item');
 
-    expect(titleElement.textContent).toBe(component.aboutMe.title);
-    expect(descriptionElement.textContent).toBe(component.aboutMe.description);
+    expect(titleElement.textContent?.trim()).toBe(component.aboutMe.title);
+    expect(paragraphElements.length).toBe(component.aboutMe.paragraphs.length);
+    expect(highlightItems.length).toBe(component.aboutMe.highlights.length);
   });
 
   /**
@@ -62,7 +72,9 @@ describe('AboutComponent', () => {
   it('should update the template when aboutMe data changes', () => {
     const newAboutMe: AboutMe = {
       title: 'New Title',
-      description: 'Updated description for testing.'
+      paragraphs: ['Paragraph one.', 'Paragraph two.'],
+      highlightsTitle: 'Highlights',
+      highlights: ['Highlight A', 'Highlight B']
     };
 
     component.aboutMe = newAboutMe;
@@ -70,9 +82,11 @@ describe('AboutComponent', () => {
 
     const compiled = fixture.nativeElement as HTMLElement;
     const titleElement = compiled.querySelector('.about-title') as HTMLElement;
-    const descriptionElement = compiled.querySelector('.about-description') as HTMLElement;
+    const paragraphElements = compiled.querySelectorAll('.about-paragraph');
+    const highlightItems = compiled.querySelectorAll('.about-list-item');
 
-    expect(titleElement.textContent).toBe(newAboutMe.title);
-    expect(descriptionElement.textContent).toBe(newAboutMe.description);
+    expect(titleElement.textContent?.trim()).toBe(newAboutMe.title);
+    expect(paragraphElements.length).toBe(newAboutMe.paragraphs.length);
+    expect(highlightItems.length).toBe(newAboutMe.highlights.length);
   });
 });

--- a/src/app/components/about/about.component.ts
+++ b/src/app/components/about/about.component.ts
@@ -16,9 +16,12 @@ import { TranslationService } from '../../services/translation.service';
 export class AboutComponent implements OnInit, OnDestroy {
   aboutMe: AboutMe = {
     title: '',
-    description: ''
+    paragraphs: [],
+    highlightsTitle: '',
+    highlights: []
   };
   isLoading = true;
+  readonly placeholders = Array.from({ length: 3 });
 
   private readonly destroy$ = new Subject<void>();
 

--- a/src/app/data/about-me.data.ts
+++ b/src/app/data/about-me.data.ts
@@ -3,16 +3,30 @@ import { AboutMeLangs } from '../dtos/AboutMeDTO';
 export const aboutMeData: AboutMeLangs = {
     it: {
         title: 'Chi Sono',
-        description: `
-      Sono uno sviluppatore software full-stack junior di 29 anni che ama imparare e realizzare prodotti affidabili con cura.
-      Dal Java, Angular e Spring Boot alle pipeline CI/CD e a Boomi, concentro il mio lavoro su idee orientate all'automazione che migliorano progressivamente i processi.
-      Mi piace collaborare in team multidisciplinari, allineando persone e tecnologia per raggiungere insieme risultati concreti.`
+        paragraphs: [
+            'Sono uno sviluppatore full-stack di 29 anni che ama trasformare le idee in prodotti digitali affidabili e curati nei dettagli.',
+            'Ho esperienza con Java, Spring Boot e Angular, oltre che con l’integrazione di piattaforme come Boomi e con la gestione di pipeline CI/CD. Questo mi permette di seguire il ciclo di vita del software end-to-end, mantenendo il focus sulla qualità e sull’automazione.',
+            'Credo nella collaborazione trasparente: metto in connessione persone, processi e tecnologia per costruire soluzioni che evolvono assieme al business.'
+        ],
+        highlightsTitle: 'Cosa porto nel team',
+        highlights: [
+            'Esperienza nella progettazione di interfacce responsive e accessibili in Angular.',
+            'Competenze backend con Java e Spring Boot per servizi scalabili e ben manutenibili.',
+            'Attenzione all’automazione: CI/CD, monitoraggio e flussi DevOps che riducono i tempi di rilascio.'
+        ]
     },
     en: {
         title: 'About Me',
-        description: `
-      I'm a 29-year-old junior full-stack software developer who enjoys learning and crafting reliable products with care.
-      From Java, Angular and Spring Boot to CI/CD pipelines and Boomi, I focus on automation-first ideas that steadily improve processes.
-      I enjoy working in collaborative teams, aligning people and technology to deliver meaningful outcomes together.`
+        paragraphs: [
+            'I am a 29-year-old full-stack developer who enjoys turning ideas into reliable, well-crafted digital products.',
+            'My experience spans Java, Spring Boot and Angular, as well as integrating platforms like Boomi and managing CI/CD pipelines. This lets me support the entire software lifecycle while keeping quality and automation front and center.',
+            'I believe in transparent collaboration: I connect people, processes and technology to deliver solutions that grow alongside the business.'
+        ],
+        highlightsTitle: 'What I bring to the team',
+        highlights: [
+            'Experience designing responsive, accessible interfaces with Angular.',
+            'Backend skills in Java and Spring Boot for scalable, maintainable services.',
+            'A focus on automation—CI/CD, monitoring and DevOps flows that shorten release cycles.'
+        ]
     }
 };

--- a/src/app/dtos/AboutMeDTO.ts
+++ b/src/app/dtos/AboutMeDTO.ts
@@ -8,5 +8,7 @@ export interface AboutMeLangs {
 
 export interface AboutMe {
     title: string;
-    description: string;
+    paragraphs: string[];
+    highlightsTitle: string;
+    highlights: string[];
 }


### PR DESCRIPTION
## Summary
- rewrite the bilingual about-me content with multi-paragraph copy and highlight lists while keeping the existing title metadata
- extend the AboutMe DTO and component template to support the richer structure and provide skeleton placeholders during loading
- restyle the about section with gradient, blur and responsive constraints consistent with the education section, adding mobile-friendly breakpoints

## Testing
- npm run build *(fails: Angular CLI not available in container PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68e3ddb8bc48832b83eb209a814e83f7