### PR TITLE
Refactor skills desktop view into timeline

### DIFF
--- a/src/app/components/skills/skills.component.html
+++ b/src/app/components/skills/skills.component.html
@@ -25,19 +25,23 @@
   <ng-template #desktopLayout>
     <div class="timeline" role="list">
       <article class="timeline-item" role="listitem" *ngFor="let section of timelineSections; let last = last">
-        <div class="timeline-marker" [class.is-last]="last">
-          <span class="timeline-dot" aria-hidden="true"></span>
+        <div class="timeline-axis" aria-hidden="true">
+          <span class="timeline-dot"></span>
+          <span class="timeline-connector" [class.is-last]="last"></span>
         </div>
-        <div class="timeline-card">
+        <div class="timeline-content">
           <header class="timeline-header">
-            <h3 class="timeline-heading">{{ section.title }}</h3>
-            <span class="timeline-badge" *ngIf="section.subtitle">{{ section.subtitle }}</span>
+            <span class="timeline-subtitle" *ngIf="section.subtitle">{{ section.subtitle }}</span>
+            <h3 class="timeline-title">{{ section.title }}</h3>
           </header>
-          <div class="skills" role="list">
-            <div *ngFor="let skill of section.skills" class="skill-item" role="listitem">
-              <img [src]="skill.icon" [alt]="skill.name" (click)="onSkillClick($event, skill)"
-                [ngClass]="{ 'clicked': skill.clicked }" />
-            </div>
+          <div class="skill-grid" role="list">
+            <button *ngFor="let skill of section.skills" type="button" class="skill-chip" role="listitem"
+              (click)="onSkillClick($event, skill)" [class.clicked]="skill.clicked">
+              <span class="chip-icon">
+                <img [src]="skill.icon" [alt]="skill.name" />
+              </span>
+              <span class="chip-label">{{ skill.name }}</span>
+            </button>
           </div>
         </div>
       </article>

--- a/src/app/components/skills/skills.component.html
+++ b/src/app/components/skills/skills.component.html
@@ -1,5 +1,5 @@
-<section *ngIf="!isLoading">
-  <h2>{{skillFullTitle}}</h2>
+<section class="skills-section" *ngIf="!isLoading">
+  <h2 class="skills-title">{{ skillFullTitle }}</h2>
 
   <!-- Carousell-->
   <div *ngIf="isMobile; else desktopLayout" class="carousel-container">
@@ -8,6 +8,7 @@
       <div *ngFor="let section of sections; let i = index" class="carousel-item" [class.active]="i === currentIndex">
         <div class="skill-section">
           <h3>{{ section.title }}</h3>
+          <p class="skill-subtitle" *ngIf="timelineSections[i]?.subtitle">{{ timelineSections[i].subtitle }}</p>
           <div class="skills">
             <div *ngFor="let skill of section.skills" class="skill-item">
               <img [src]="skill.icon" [alt]="skill.name" (click)="onSkillClick($event, skill)"
@@ -22,16 +23,24 @@
 
   <!-- Desktop -->
   <ng-template #desktopLayout>
-    <div class="skill-grid">
-      <div *ngFor="let section of sections" class="skill-section">
-        <h3>{{ section.title }}</h3>
-        <div class="skills">
-          <div *ngFor="let skill of section.skills" class="skill-item">
-            <img [src]="skill.icon" [alt]="skill.name" (click)="onSkillClick($event, skill)"
-              [ngClass]="{'clicked': skill.clicked}" />
+    <div class="timeline" role="list">
+      <article class="timeline-item" role="listitem" *ngFor="let section of timelineSections; let last = last">
+        <div class="timeline-marker" [class.is-last]="last">
+          <span class="timeline-dot" aria-hidden="true"></span>
+        </div>
+        <div class="timeline-card">
+          <header class="timeline-header">
+            <h3 class="timeline-heading">{{ section.title }}</h3>
+            <span class="timeline-badge" *ngIf="section.subtitle">{{ section.subtitle }}</span>
+          </header>
+          <div class="skills" role="list">
+            <div *ngFor="let skill of section.skills" class="skill-item" role="listitem">
+              <img [src]="skill.icon" [alt]="skill.name" (click)="onSkillClick($event, skill)"
+                [ngClass]="{ 'clicked': skill.clicked }" />
+            </div>
           </div>
         </div>
-      </div>
+      </article>
     </div>
   </ng-template>
 </section>

--- a/src/app/components/skills/skills.component.scss
+++ b/src/app/components/skills/skills.component.scss
@@ -1,85 +1,207 @@
-section {
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
+:host {
+  --timeline-accent: #6366f1;
+  --timeline-accent-soft: rgba(99, 102, 241, 0.18);
+  --timeline-card-bg: rgba(15, 23, 42, 0.05);
+  --timeline-card-border: rgba(99, 102, 241, 0.25);
+  --timeline-text-muted: rgba(15, 23, 42, 0.65);
 }
 
-// Container della griglia delle competenze
-.skill-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-    gap: 2rem;
-    width: 100%;
-    max-width: 1200px;
+.skills-section {
+  min-height: 100vh;
+  padding: clamp(2rem, 4vw, 4.5rem) clamp(1.25rem, 3vw, 3rem);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: linear-gradient(160deg, rgba(99, 102, 241, 0.08), rgba(79, 70, 229, 0));
+  gap: clamp(2rem, 4vw, 3rem);
 }
 
-// Contenitore della sezione di abilità
+.skills-title {
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+  font-weight: 700;
+  text-align: center;
+  margin: 0;
+}
+
 .skill-section {
-    border-radius: 8px;
-    padding: 2rem;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: flex-start;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  align-items: center;
+  text-align: center;
+}
 
-    .skills {
-        display: flex;
-        flex-wrap: wrap;
-        justify-content: center;
-        width: 100%;
-        gap: 0.5rem;
+.skill-subtitle {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: var(--timeline-text-muted);
+}
 
-        .skill-item {
-            text-align: center;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
+.skills {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem;
+}
 
-            img {
-                object-fit: contain;
-                transition: box-shadow 0.3s ease-in-out, transform 0.3s ease-in-out;
-                cursor: pointer;
+.skill-item {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
 
-                &:hover {
-                    transform: translateY(-5px);
-                }
+.skill-item img {
+  object-fit: contain;
+  transition: box-shadow 0.3s ease-in-out, transform 0.3s ease-in-out;
+  cursor: pointer;
+}
 
-                &.clicked {
-                    transform: translateY(-5px) rotate(360deg);
-                }
-            }
-        }
-    }
+.skill-item img:hover,
+.skill-item img.clicked {
+  transform: translateY(-4px);
+}
+
+.timeline {
+  --timeline-gap: clamp(1.75rem, 3vw, 2.75rem);
+  width: min(80vw, 960px);
+  display: grid;
+  gap: var(--timeline-gap);
+  margin: 0 auto;
+}
+
+.timeline-item {
+  display: grid;
+  grid-template-columns: 3.5rem 1fr;
+  column-gap: clamp(1.25rem, 2.5vw, 2rem);
+  align-items: start;
+}
+
+.timeline-marker {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+}
+
+.timeline-marker::before {
+  content: "";
+  position: absolute;
+  top: 0.5rem;
+  left: calc(50% - 1.5px);
+  width: 3px;
+  bottom: calc(var(--timeline-gap) * -1);
+  background: linear-gradient(180deg, var(--timeline-accent), rgba(99, 102, 241, 0));
+  border-radius: 999px;
+}
+
+.timeline-marker.is-last::before {
+  bottom: 0;
+}
+
+.timeline-dot {
+  margin-top: 0.25rem;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--timeline-accent);
+  box-shadow: 0 0 0 6px var(--timeline-accent-soft), 0 10px 30px rgba(79, 70, 229, 0.18);
+}
+
+.timeline-card {
+  background: linear-gradient(135deg, var(--timeline-card-bg), rgba(99, 102, 241, 0.1));
+  border: 1px solid var(--timeline-card-border);
+  border-radius: 18px;
+  padding: clamp(1.25rem, 3vw, 2rem);
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
+  backdrop-filter: blur(6px);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.timeline-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: baseline;
+}
+
+.timeline-heading {
+  margin: 0;
+  font-size: clamp(1.1rem, 2.4vw, 1.4rem);
+  font-weight: 600;
+}
+
+.timeline-badge {
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(99, 102, 241, 0.15);
+  color: var(--timeline-accent);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.carousel-container {
+  width: min(90vw, 540px);
+  margin: 0 auto;
+}
+
+.carousel-container .skill-section {
+  background: linear-gradient(135deg, var(--timeline-card-bg), rgba(99, 102, 241, 0.1));
+  border: 1px solid var(--timeline-card-border);
+  border-radius: 18px;
+  padding: clamp(1.5rem, 4vw, 2rem);
+  box-shadow: 0 16px 35px rgba(15, 23, 42, 0.1);
 }
 
 @media (max-width: 768px) {
-    .skill-grid {
-        display: none; // Nascondi la griglia per dispositivi mobili
-    }
+  .timeline {
+    --timeline-gap: clamp(1.5rem, 4vw, 2rem);
+  }
 
-    .carousel-container {
-        display: block;
-        padding: 1.5rem;
+  .timeline-item {
+    grid-template-columns: 2.75rem 1fr;
+  }
 
-        .skill-section {
-            padding: 1.5rem;
-        }
-    }
+  .timeline-badge {
+    font-size: 0.8rem;
+  }
+}
+
+@media (max-width: 600px) {
+  .skills-section {
+    padding: clamp(2rem, 6vw, 3.5rem) clamp(1rem, 4vw, 2rem);
+  }
+
+  .timeline-item {
+    position: relative;
+    grid-template-columns: 1fr;
+    row-gap: 1rem;
+    padding-left: 2.5rem;
+  }
+
+  .timeline-marker {
+    position: absolute;
+    inset: 1rem auto auto 0;
+    width: 2.5rem;
+  }
+
+  .timeline-marker::before {
+    left: calc(1.25rem - 1.5px);
+    top: 0.75rem;
+  }
+
+  .timeline-dot {
+    margin-top: 0;
+  }
 }
 
 @media (max-width: 480px) {
-
-    .skill-grid {
-        grid-template-columns: 1fr; // Modifica per schermi molto piccoli
-    }
-
-    .carousel-container {
-
-        .arrow-left,
-        .arrow-right {
-            font-size: 1.5rem; // Riduci la dimensione delle frecce su schermi più piccoli
-        }
-    }
+  .carousel-container .arrow-left,
+  .carousel-container .arrow-right {
+    font-size: 1.5rem;
+  }
 }

--- a/src/app/components/skills/skills.component.scss
+++ b/src/app/components/skills/skills.component.scss
@@ -1,9 +1,10 @@
 :host {
-  --timeline-accent: #6366f1;
-  --timeline-accent-soft: rgba(99, 102, 241, 0.18);
-  --timeline-card-bg: rgba(15, 23, 42, 0.05);
-  --timeline-card-border: rgba(99, 102, 241, 0.25);
-  --timeline-text-muted: rgba(15, 23, 42, 0.65);
+  --timeline-axis: linear-gradient(180deg, #818cf8, rgba(129, 140, 248, 0));
+  --timeline-dot-shadow: 0 0 0 8px rgba(129, 140, 248, 0.18), 0 16px 38px rgba(79, 70, 229, 0.22);
+  --timeline-subtitle: rgba(15, 23, 42, 0.65);
+  --chip-bg: linear-gradient(135deg, rgba(99, 102, 241, 0.16), rgba(59, 130, 246, 0.14));
+  --chip-border: rgba(99, 102, 241, 0.35);
+  --chip-text: #0f172a;
 }
 
 .skills-section {
@@ -12,8 +13,8 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  background: linear-gradient(160deg, rgba(99, 102, 241, 0.08), rgba(79, 70, 229, 0));
   gap: clamp(2rem, 4vw, 3rem);
+  background: linear-gradient(160deg, rgba(99, 102, 241, 0.08), rgba(59, 130, 246, 0));
 }
 
 .skills-title {
@@ -35,7 +36,7 @@
   margin: 0;
   font-size: 0.95rem;
   font-weight: 500;
-  color: var(--timeline-text-muted);
+  color: var(--timeline-subtitle);
 }
 
 .skills {
@@ -47,23 +48,24 @@
 
 .skill-item {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-content: center;
+  gap: 0.45rem;
 }
 
 .skill-item img {
   object-fit: contain;
-  transition: box-shadow 0.3s ease-in-out, transform 0.3s ease-in-out;
+  transition: transform 0.3s ease;
   cursor: pointer;
 }
 
 .skill-item img:hover,
 .skill-item img.clicked {
-  transform: translateY(-4px);
+  transform: translateY(-4px) scale(1.02);
 }
 
 .timeline {
-  --timeline-gap: clamp(1.75rem, 3vw, 2.75rem);
+  --timeline-gap: clamp(1.75rem, 3vw, 2.5rem);
   width: min(80vw, 960px);
   display: grid;
   gap: var(--timeline-gap);
@@ -72,76 +74,150 @@
 
 .timeline-item {
   display: grid;
-  grid-template-columns: 3.5rem 1fr;
-  column-gap: clamp(1.25rem, 2.5vw, 2rem);
+  grid-template-columns: clamp(3rem, 5vw, 4rem) 1fr;
+  gap: clamp(1.25rem, 3vw, 2rem);
   align-items: start;
 }
 
-.timeline-marker {
+.timeline-axis {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  justify-items: center;
   position: relative;
-  display: flex;
-  justify-content: center;
-  align-items: flex-start;
-}
-
-.timeline-marker::before {
-  content: "";
-  position: absolute;
-  top: 0.5rem;
-  left: calc(50% - 1.5px);
-  width: 3px;
-  bottom: calc(var(--timeline-gap) * -1);
-  background: linear-gradient(180deg, var(--timeline-accent), rgba(99, 102, 241, 0));
-  border-radius: 999px;
-}
-
-.timeline-marker.is-last::before {
-  bottom: 0;
 }
 
 .timeline-dot {
-  margin-top: 0.25rem;
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  background: var(--timeline-accent);
-  box-shadow: 0 0 0 6px var(--timeline-accent-soft), 0 10px 30px rgba(79, 70, 229, 0.18);
+  width: 20px;
+  height: 20px;
+  border-radius: 999px;
+  background: radial-gradient(circle at 30% 30%, #eef2ff, #6366f1 65%);
+  box-shadow: var(--timeline-dot-shadow);
+  position: relative;
+  z-index: 1;
 }
 
-.timeline-card {
-  background: linear-gradient(135deg, var(--timeline-card-bg), rgba(99, 102, 241, 0.1));
-  border: 1px solid var(--timeline-card-border);
-  border-radius: 18px;
-  padding: clamp(1.25rem, 3vw, 2rem);
-  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
-  backdrop-filter: blur(6px);
+.timeline-connector {
+  width: 3px;
+  margin-top: 0.25rem;
+  border-radius: 999px;
+  background: var(--timeline-axis);
+}
+
+.timeline-connector.is-last {
+  display: none;
+}
+
+.timeline-content {
+  position: relative;
+  padding: clamp(1.5rem, 3vw, 2.5rem);
+  padding-left: clamp(1.75rem, 3vw, 2.75rem);
+  border-radius: 24px;
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: clamp(1rem, 2vw, 1.5rem);
+  isolation: isolate;
+}
+
+.timeline-content::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(148, 163, 253, 0.2), rgba(191, 219, 254, 0.15));
+  border: 1px solid rgba(129, 140, 248, 0.25);
+  backdrop-filter: blur(12px);
+  opacity: 0.85;
+  z-index: -2;
+}
+
+.timeline-content::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(120deg, rgba(99, 102, 241, 0.2), transparent 55%);
+  z-index: -1;
+  opacity: 0.45;
 }
 
 .timeline-header {
   display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  gap: 0.75rem;
-  align-items: baseline;
+  flex-direction: column;
+  gap: 0.35rem;
 }
 
-.timeline-heading {
-  margin: 0;
-  font-size: clamp(1.1rem, 2.4vw, 1.4rem);
-  font-weight: 600;
-}
-
-.timeline-badge {
-  padding: 0.35rem 0.75rem;
-  border-radius: 999px;
-  background: rgba(99, 102, 241, 0.15);
-  color: var(--timeline-accent);
+.timeline-subtitle {
   font-size: 0.85rem;
   font-weight: 600;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--timeline-subtitle);
+}
+
+.timeline-title {
+  margin: 0;
+  font-size: clamp(1.25rem, 2.8vw, 1.75rem);
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.skill-grid {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  gap: 0.75rem;
+}
+
+.skill-chip {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.65rem 0.9rem;
+  border-radius: 999px;
+  background: var(--chip-bg);
+  color: var(--chip-text);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
+  cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+  border: 1px solid var(--chip-border);
+}
+
+.skill-chip .chip-icon {
+  width: 2.25rem;
+  height: 2.25rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.6);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.4);
+}
+
+.skill-chip img {
+  width: 1.5rem;
+  height: 1.5rem;
+  object-fit: contain;
+}
+
+.skill-chip.clicked,
+.skill-chip:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 15px 35px rgba(99, 102, 241, 0.25);
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.22), rgba(59, 130, 246, 0.05));
+}
+
+.skill-chip:focus-visible {
+  outline: 2px solid #6366f1;
+  outline-offset: 3px;
+}
+
+.chip-label {
+  white-space: nowrap;
 }
 
 .carousel-container {
@@ -150,11 +226,17 @@
 }
 
 .carousel-container .skill-section {
-  background: linear-gradient(135deg, var(--timeline-card-bg), rgba(99, 102, 241, 0.1));
-  border: 1px solid var(--timeline-card-border);
-  border-radius: 18px;
-  padding: clamp(1.5rem, 4vw, 2rem);
-  box-shadow: 0 16px 35px rgba(15, 23, 42, 0.1);
+  background: linear-gradient(135deg, rgba(148, 163, 253, 0.25), rgba(59, 130, 246, 0.12));
+  border: 1px solid rgba(99, 102, 241, 0.25);
+  border-radius: 22px;
+  padding: clamp(1.5rem, 4vw, 2.25rem);
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.12);
+}
+
+@media (max-width: 1024px) {
+  .timeline {
+    width: min(88vw, 960px);
+  }
 }
 
 @media (max-width: 768px) {
@@ -163,10 +245,15 @@
   }
 
   .timeline-item {
-    grid-template-columns: 2.75rem 1fr;
+    grid-template-columns: clamp(2.5rem, 7vw, 3rem) 1fr;
   }
 
-  .timeline-badge {
+  .timeline-content {
+    padding: clamp(1.25rem, 4vw, 2rem);
+    padding-left: clamp(1.5rem, 3vw, 2rem);
+  }
+
+  .skill-chip {
     font-size: 0.8rem;
   }
 }
@@ -179,23 +266,18 @@
   .timeline-item {
     position: relative;
     grid-template-columns: 1fr;
-    row-gap: 1rem;
-    padding-left: 2.5rem;
+    gap: 1rem;
+    padding-left: 2.75rem;
   }
 
-  .timeline-marker {
+  .timeline-axis {
     position: absolute;
-    inset: 1rem auto auto 0;
+    inset: 0 auto auto 0;
     width: 2.5rem;
   }
 
-  .timeline-marker::before {
-    left: calc(1.25rem - 1.5px);
-    top: 0.75rem;
-  }
-
-  .timeline-dot {
-    margin-top: 0;
+  .timeline-connector {
+    height: calc(100% - 24px);
   }
 }
 

--- a/src/app/components/skills/skills.component.ts
+++ b/src/app/components/skills/skills.component.ts
@@ -202,14 +202,15 @@ export class SkillsComponent implements OnInit, OnDestroy {
       border-radius: 10px;
     `;
 
-    const parent = targetElement.parentElement;
+    const host = targetElement.closest('.skill-chip, .skill-item');
 
-    if (!parent) {
-      console.warn('Unable to attach popup message: parent element not found.');
+    if (!(host instanceof HTMLElement)) {
+      console.warn('Unable to attach popup message: host element not found.');
       return null;
     }
 
-    parent.appendChild(message);
+    host.style.position = 'relative';
+    host.appendChild(message);
     return message;
   }
 

--- a/src/app/components/skills/skills.component.ts
+++ b/src/app/components/skills/skills.component.ts
@@ -202,14 +202,21 @@ export class SkillsComponent implements OnInit, OnDestroy {
       border-radius: 10px;
     `;
 
-    const host = targetElement.closest('.skill-chip, .skill-item');
+    let host = targetElement.closest('.skill-chip, .skill-item');
+
+    if (!(host instanceof HTMLElement)) {
+      host = targetElement.parentElement;
+    }
 
     if (!(host instanceof HTMLElement)) {
       console.warn('Unable to attach popup message: host element not found.');
       return null;
     }
 
-    host.style.position = 'relative';
+    if (getComputedStyle(host).position === 'static') {
+      host.style.position = 'relative';
+    }
+
     host.appendChild(message);
     return message;
   }

--- a/src/app/components/skills/skills.component.ts
+++ b/src/app/components/skills/skills.component.ts
@@ -17,12 +17,85 @@ import { TranslationService } from '../../services/translation.service';
 export class SkillsComponent implements OnInit, OnDestroy {
   skillFullTitle = '';
   sections: SkillSection[] = [];
+  timelineSections: Array<SkillSection & { subtitle: string }> = [];
   isLoading = true;
   isMobile = false;
   currentIndex = 0;
   isBrowser = false;
+  currentLanguage: LanguageCode = 'it';
 
   private readonly destroy$ = new Subject<void>();
+  private readonly timelineSubtitleDictionary: Record<string, Record<string, string>> = {
+    it: {
+      'Linguaggi di Programmazione': 'Fondamenta del linguaggio',
+      'Front-end e UI': 'Interfacce dinamiche',
+      'Back-end e Servizi': 'Servizi applicativi',
+      'Database': 'Gestione dei dati',
+      'Cloud e DevOps': 'DevOps e scalabilità',
+      'Integrazione e Automazione': 'Integrazione enterprise',
+      'Testing e Documentazione': 'Qualità e API',
+      'Build e CI': 'Pipeline di delivery',
+      'Version Control': 'Versionamento continuo',
+      'Collaborazione e Management': 'Collaborazione quotidiana',
+      'Sistemi Operativi': 'Ambiente operativo'
+    },
+    en: {
+      'Programming Languages': 'Foundational languages',
+      'Front-end & UI': 'User interface craftsmanship',
+      'Back-end & Services': 'Service layer tooling',
+      'Database': 'Data foundations',
+      'Cloud & DevOps': 'Platform & scalability',
+      'Integration & Automation': 'Enterprise integration',
+      'Testing & Documentation': 'Quality assurance',
+      'Build & CI': 'Delivery pipeline',
+      'Version Control': 'Source control',
+      'Collaboration & Management': 'Team collaboration',
+      'Operating Systems': 'Runtime environments'
+    },
+    default: {}
+  };
+
+  private readonly timelineStageFallbacks: Record<string, string[]> = {
+    it: [
+      'Fondamenta del linguaggio',
+      'Interfacce dinamiche',
+      'Servizi applicativi',
+      'Gestione dei dati',
+      'DevOps e scalabilità',
+      'Integrazione enterprise',
+      'Qualità e API',
+      'Pipeline di delivery',
+      'Versionamento continuo',
+      'Collaborazione quotidiana',
+      'Ambiente operativo'
+    ],
+    en: [
+      'Foundational languages',
+      'User interface craftsmanship',
+      'Service layer tooling',
+      'Data foundations',
+      'Platform & scalability',
+      'Enterprise integration',
+      'Quality assurance',
+      'Delivery pipeline',
+      'Source control',
+      'Team collaboration',
+      'Runtime environments'
+    ],
+    default: [
+      'Core foundations',
+      'Interface experiences',
+      'Application services',
+      'Data foundations',
+      'Platform & scalability',
+      'Enterprise integration',
+      'Quality assurance',
+      'Delivery pipeline',
+      'Source control',
+      'Team collaboration',
+      'Runtime environments'
+    ]
+  };
 
   constructor(
     private translationService: TranslationService,
@@ -39,6 +112,7 @@ export class SkillsComponent implements OnInit, OnDestroy {
           this.isLoading = true;
         }),
         switchMap((lang) => {
+          this.currentLanguage = lang;
           const source = this.resolveLocalizedContent(skillsData);
           return this.translationService.translateContent<SkillFull>(
             source.content,
@@ -50,6 +124,7 @@ export class SkillsComponent implements OnInit, OnDestroy {
       .subscribe(translated => {
         this.skillFullTitle = translated.title;
         this.sections = translated.skills.map(section => this.resetSection(section));
+        this.timelineSections = this.buildTimelineSections(this.sections);
         this.currentIndex = 0;
         this.isLoading = false;
       });
@@ -143,6 +218,25 @@ export class SkillsComponent implements OnInit, OnDestroy {
       ...section,
       skills: section.skills.map(skill => ({ ...skill, clicked: false }))
     };
+  }
+
+  private buildTimelineSections(sections: SkillSection[]): Array<SkillSection & { subtitle: string }> {
+    const stageFallbacks = this.timelineStageFallbacks[this.currentLanguage] ?? this.timelineStageFallbacks['default'];
+
+    return sections.map((section, index) => {
+      const subtitleDictionary = this.timelineSubtitleDictionary[this.currentLanguage] ?? this.timelineSubtitleDictionary['default'];
+      const subtitle = section.subtitle
+        ?? subtitleDictionary?.[section.title]
+        ?? this.timelineSubtitleDictionary['default']?.[section.title]
+        ?? stageFallbacks[index]
+        ?? stageFallbacks[stageFallbacks.length - 1]
+        ?? '';
+
+      return {
+        ...section,
+        subtitle
+      };
+    });
   }
 
   private resolveLocalizedContent<T>(

--- a/src/app/components/skills/skills.component.ts
+++ b/src/app/components/skills/skills.component.ts
@@ -173,9 +173,9 @@ export class SkillsComponent implements OnInit, OnDestroy {
       return;
     }
 
-    const resolvedTarget = (event.currentTarget ?? event.target);
+    const resolvedTarget = (event.currentTarget ?? event.target) as EventTarget | null;
 
-    if (!(resolvedTarget instanceof HTMLElement)) {
+    if (!(resolvedTarget instanceof Element)) {
       console.warn('Skill click target is not an HTMLElement.');
       return;
     }
@@ -186,7 +186,7 @@ export class SkillsComponent implements OnInit, OnDestroy {
     }
   }
 
-  createPopupMessage(targetElement: HTMLElement): HTMLElement | null {
+  createPopupMessage(targetElement: Element): HTMLElement | null {
     const message = document.createElement('div');
     message.classList.add('popup');
     message.style.cssText = `
@@ -202,23 +202,32 @@ export class SkillsComponent implements OnInit, OnDestroy {
       border-radius: 10px;
     `;
 
-    let host = targetElement.closest('.skill-chip, .skill-item');
+    const host = this.resolvePopupHost(targetElement);
 
-    if (!(host instanceof HTMLElement)) {
-      host = targetElement.parentElement;
-    }
-
-    if (!(host instanceof HTMLElement)) {
+    if (!host) {
       console.warn('Unable to attach popup message: host element not found.');
       return null;
     }
 
-    if (getComputedStyle(host).position === 'static') {
+    if (host instanceof HTMLElement && getComputedStyle(host).position === 'static') {
       host.style.position = 'relative';
     }
 
     host.appendChild(message);
     return message;
+  }
+
+  private resolvePopupHost(targetElement: Element): Element | null {
+    const timelineHost = targetElement.closest('.skill-chip, .skill-item, [data-skill-host]');
+    if (timelineHost) {
+      return timelineHost;
+    }
+
+    if (targetElement.parentElement) {
+      return targetElement.parentElement;
+    }
+
+    return targetElement instanceof HTMLElement ? targetElement : null;
   }
 
   private resetSection(section: SkillSection): SkillSection {

--- a/src/app/dtos/SkillDTO.ts
+++ b/src/app/dtos/SkillDTO.ts
@@ -7,6 +7,7 @@ export interface SkillFull {
 
 export interface SkillSection {
     title: string;
+    subtitle?: string;
     skills: SkillItem[];
 }
 


### PR DESCRIPTION
## Summary
- replace the desktop skills grid with a timeline layout featuring markers, badges, and grouped skills
- mirror the education component styling for the skills timeline, including timeline variables and responsive tweaks
- expose timeline-ready skill sections with localized subtitles and desktop carousel disablement

## Testing
- npm install *(fails: 403 Forbidden fetching @angular/compiler-cli)*

------
https://chatgpt.com/codex/tasks/task_e_68e3ddbddffc832bb4ff26fec3676c3c