### PR TITLE
Adjust layout of home floating controls

### DIFF
--- a/src/app/pages/home/home.component.scss
+++ b/src/app/pages/home/home.component.scss
@@ -3,7 +3,7 @@
   bottom: 30px;
   right: 30px;
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   align-items: flex-end;
   gap: 12px;
   z-index: 9999;
@@ -22,6 +22,8 @@
 
 @media (max-width: 768px) {
   .home__floating-controls {
+    flex-direction: column;
+    align-items: flex-end;
     bottom: 18px;
     right: 18px;
     gap: 10px;


### PR DESCRIPTION
## Summary
- arrange the home floating controls horizontally so navigator and assistant share the same row
- keep column layout for narrow screens to preserve responsive behaviour

## Testing
- npm run build *(fails: ng not found in container)*
- npm run test *(fails: ng not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e422adfdfc832bbcebf3b14b07539f