### PR TITLE
Add close control to navigator component

### DIFF
--- a/src/app/components/navigator/navigator.component.html
+++ b/src/app/components/navigator/navigator.component.html
@@ -67,5 +67,11 @@
         </button>
       </div>
     </div>
+
+    <button class="nav-button close-button" (click)="closeNavigator()"
+      [attr.aria-label]="getCloseButtonLabel()"
+      [matTooltip]="getCloseButtonLabel()" matTooltipPosition="left">
+      <mat-icon>close</mat-icon>
+    </button>
   </div>
 </div>

--- a/src/app/components/navigator/navigator.component.scss
+++ b/src/app/components/navigator/navigator.component.scss
@@ -164,6 +164,14 @@ $navigator-themes: (
             font-weight: 600;
             color: var(--navigator-text-color);
         }
+
+        &.close-button {
+            margin-top: 4px;
+
+            mat-icon {
+                font-size: $navigator-icon-size;
+            }
+        }
     }
 
     .arrow-button {

--- a/src/app/components/navigator/navigator.component.spec.ts
+++ b/src/app/components/navigator/navigator.component.spec.ts
@@ -84,6 +84,23 @@ describe('NavigatorComponent', () => {
     expect(component.showThemeOptions).toBeFalse();
   });
 
+  it('should close navigator and reset menus when close button is clicked', () => {
+    component.isOpen = true;
+    component.showLanguageOptions = true;
+    component.showThemeOptions = true;
+    fixture.detectChanges();
+
+    const closeButton: HTMLButtonElement = fixture.nativeElement.querySelector('.close-button');
+    expect(closeButton).withContext('Close button should be rendered when navigator is open').toBeTruthy();
+
+    closeButton.click();
+    fixture.detectChanges();
+
+    expect(component.isOpen).toBeFalse();
+    expect(component.showLanguageOptions).toBeFalse();
+    expect(component.showThemeOptions).toBeFalse();
+  });
+
   it('should keep the navigator open for wheel events that originate within the component', () => {
     component.isOpen = true;
     component.showLanguageOptions = true;

--- a/src/app/components/navigator/navigator.component.ts
+++ b/src/app/components/navigator/navigator.component.ts
@@ -62,6 +62,13 @@ export class NavigatorComponent implements OnInit {
     }
   };
 
+  closeButtonLabels: { [key: string]: string } = {
+    en: 'Close navigator',
+    it: 'Chiudi navigatore',
+    de: 'Navigator schließen',
+    es: 'Cerrar navegador'
+  };
+
   constructor(
     private translationService: TranslationService,
     @Inject(PLATFORM_ID) private platformId: Object,
@@ -128,6 +135,10 @@ export class NavigatorComponent implements OnInit {
   /** Returns the tooltip text for the given key based on current language */
   getTooltip(key: 'prev' | 'next' | 'theme' | 'language'): string {
     return this.tooltipTexts[this.currentLang][key];
+  }
+
+  getCloseButtonLabel(): string {
+    return this.closeButtonLabels[this.currentLang] || this.closeButtonLabels['en'];
   }
 
   private applyTheme(theme: 'light' | 'dark' | 'blue' | 'green'): void {


### PR DESCRIPTION
## Summary
- add a dedicated close button to the navigator panel wired to closeNavigator
- expose localized labels for the new control and align styles with the vertical layout
- verify the close button through a unit test that ensures the navigator closes and menus reset

## Testing
- `npm run build` *(fails: `ng` command not available because dependencies cannot be installed in the execution environment)*
- `npm run test` *(fails: `ng` command not available because dependencies cannot be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e422abe61c832bbe1a2e0495ed0601