### PR TITLE
feat: add assistant sleep-to-impatient animation cycle

### DIFF
--- a/src/app/components/assistant/assistant.component.html
+++ b/src/app/components/assistant/assistant.component.html
@@ -1,8 +1,9 @@
 <div class="assistant"
      [class.assistant--open]="isOpen"
-     [class.assistant--phase-idle]="animationPhase === 'idle'"
-     [class.assistant--phase-wondering]="animationPhase === 'wondering'"
-     [class.assistant--phase-suggest-close]="animationPhase === 'suggestClose'">
+     [class.assistant--phase-sleeping]="animationPhase === 'sleeping'"
+     [class.assistant--phase-waking]="animationPhase === 'waking'"
+     [class.assistant--phase-jumping]="animationPhase === 'jumping'"
+     [class.assistant--phase-impatient]="animationPhase === 'impatient'">
   <div class="assistant__anchor">
     <button type="button"
             class="assistant__avatar"
@@ -13,8 +14,14 @@
       <span class="assistant__avatar-wave" aria-hidden="true"></span>
       <svg class="assistant__avatar-face" viewBox="0 0 120 120" role="img" aria-hidden="true">
         <circle cx="60" cy="60" r="58" class="assistant__avatar-outline" />
-        <circle cx="45" cy="52" r="8" class="assistant__avatar-eye" />
-        <circle cx="75" cy="52" r="8" class="assistant__avatar-eye" />
+        <g class="assistant__avatar-eye assistant__avatar-eye--left">
+          <circle cx="45" cy="52" r="8" class="assistant__avatar-eye-open" />
+          <path d="M37 52 Q45 48 53 52" class="assistant__avatar-eye-closed" />
+        </g>
+        <g class="assistant__avatar-eye assistant__avatar-eye--right">
+          <circle cx="75" cy="52" r="8" class="assistant__avatar-eye-open" />
+          <path d="M67 52 Q75 48 83 52" class="assistant__avatar-eye-closed" />
+        </g>
         <path d="M40 78 C52 92 68 92 80 78" class="assistant__avatar-smile" />
       </svg>
     </button>
@@ -44,7 +51,7 @@
       </ol>
 
       <p class="assistant__closing"
-         [class.assistant__closing--active]="animationPhase === 'suggestClose'">
+         [class.assistant__closing--active]="animationPhase === 'impatient'">
         {{ guide.closingHint }}
       </p>
     </div>

--- a/src/app/components/assistant/assistant.component.scss
+++ b/src/app/components/assistant/assistant.component.scss
@@ -37,7 +37,7 @@
   place-items: center;
   background: radial-gradient(circle at 30% 30%, #ffe081, #ffb347 55%, #ff8c61 100%);
   box-shadow: 0 16px 30px rgba(0, 0, 0, 0.25);
-  transition: transform 0.35s ease, box-shadow 0.35s ease;
+  transition: box-shadow 0.35s ease;
   outline: none;
 }
 
@@ -55,8 +55,18 @@
   fill: rgba(255, 255, 255, 0.94);
 }
 
-.assistant__avatar-eye {
+.assistant__avatar-eye-open {
   fill: #2c3e50;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.assistant__avatar-eye-closed {
+  fill: none;
+  stroke: #2c3e50;
+  stroke-width: 4px;
+  stroke-linecap: round;
+  opacity: 0;
+  transition: opacity 0.3s ease, transform 0.3s ease;
 }
 
 .assistant__avatar-smile {
@@ -148,24 +158,46 @@
   line-height: 1.45;
 }
 
-.assistant--open .assistant__avatar {
-  transform: translateY(calc(-100% - var(--assistant-spacing)));
+.assistant--phase-sleeping .assistant__avatar {
+  animation: assistant-sleep 3.5s ease-in-out infinite;
 }
 
-.assistant--phase-idle .assistant__avatar {
-  animation: assistant-invite 2.5s ease-in-out infinite;
+.assistant--phase-sleeping .assistant__avatar-wave {
+  animation: assistant-sleep-wave 4s ease-in-out infinite;
+  opacity: 0.45;
 }
 
-.assistant--phase-idle .assistant__avatar-wave {
-  animation: assistant-wave 2.5s ease-in-out infinite;
+.assistant--phase-sleeping .assistant__avatar-eye-open {
+  opacity: 0;
+  transform: translateY(4px) scaleY(0.2);
 }
 
-.assistant--phase-wondering .assistant__avatar {
-  animation: assistant-wondering 3.2s ease-in-out infinite;
+.assistant--phase-sleeping .assistant__avatar-eye-closed {
+  opacity: 1;
 }
 
-.assistant--phase-suggest-close .assistant__avatar {
-  animation: assistant-suggest-close 1.8s ease-in-out infinite;
+.assistant--phase-waking .assistant__avatar {
+  animation: assistant-wake 0.6s ease-out forwards;
+}
+
+.assistant--phase-waking .assistant__avatar-eye-open {
+  transform: translateY(-2px) scaleY(1.05);
+}
+
+.assistant--phase-jumping .assistant__avatar {
+  animation: assistant-jump 0.7s cubic-bezier(0.26, 0.86, 0.32, 1.18) forwards;
+}
+
+.assistant--phase-impatient .assistant__avatar {
+  animation: assistant-impatient 1s ease-in-out infinite;
+}
+
+.assistant--phase-impatient .assistant__avatar-smile {
+  animation: assistant-impatient-smile 1s ease-in-out infinite;
+}
+
+.assistant--phase-impatient .assistant__avatar-eye-open {
+  transform: translateY(-1px) scaleY(0.95);
 }
 
 .assistant__closing {
@@ -178,7 +210,7 @@
   animation: assistant-closing-pulse 1.4s ease-in-out infinite;
 }
 
-@keyframes assistant-invite {
+@keyframes assistant-sleep {
   0%,
   100% {
     transform: translateY(0) scale(1);
@@ -186,47 +218,83 @@
   }
 
   50% {
-    transform: translateY(-6px) scale(1.05);
-    box-shadow: 0 24px 34px rgba(0, 0, 0, 0.28);
+    transform: translateY(-6px) scale(0.97);
+    box-shadow: 0 20px 32px rgba(0, 0, 0, 0.28);
   }
 }
 
-@keyframes assistant-wave {
+@keyframes assistant-sleep-wave {
   0%,
   100% {
-    opacity: 0;
-    transform: scale(0.9);
+    opacity: 0.45;
+    transform: scale(0.95);
   }
 
   50% {
-    opacity: 1;
+    opacity: 0.9;
     transform: scale(1.1);
   }
 }
 
-@keyframes assistant-wondering {
-  0%,
-  100% {
-    transform: translateY(calc(-100% - var(--assistant-spacing))) rotate(0deg);
+@keyframes assistant-wake {
+  0% {
+    transform: translateY(0) scale(1);
   }
 
-  50% {
-    transform: translateY(calc(-100% - var(--assistant-spacing) - 6px)) rotate(2deg);
+  40% {
+    transform: translateY(-18px) scale(1.08);
+  }
+
+  70% {
+    transform: translateY(6px) scale(0.96);
+  }
+
+  100% {
+    transform: translateY(0) scale(1);
   }
 }
 
-@keyframes assistant-suggest-close {
+@keyframes assistant-jump {
+  0% {
+    transform: translate(0, 0) scale(1);
+  }
+
+  40% {
+    transform: translate(-20%, -60%) scale(0.98);
+  }
+
+  70% {
+    transform: translate(-45%, -105%) scale(1.02);
+  }
+
+  100% {
+    transform: translate(-55%, -120%) scale(1);
+  }
+}
+
+@keyframes assistant-impatient {
   0%,
   100% {
-    transform: translateY(calc(-100% - var(--assistant-spacing))) rotate(0deg);
+    transform: translate(-55%, -120%) rotate(0deg) scale(1);
   }
 
-  25% {
-    transform: translateY(calc(-100% - var(--assistant-spacing))) rotate(3deg);
+  20% {
+    transform: translate(-58%, -123%) rotate(-5deg) scale(1.01);
   }
 
-  75% {
-    transform: translateY(calc(-100% - var(--assistant-spacing))) rotate(-3deg);
+  60% {
+    transform: translate(-52%, -117%) rotate(6deg) scale(1.01);
+  }
+}
+
+@keyframes assistant-impatient-smile {
+  0%,
+  100% {
+    stroke-width: 6px;
+  }
+
+  40% {
+    stroke-width: 7px;
   }
 }
 

--- a/src/app/components/assistant/assistant.component.spec.ts
+++ b/src/app/components/assistant/assistant.component.spec.ts
@@ -1,5 +1,10 @@
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { AssistantComponent } from './assistant.component';
+import {
+  ASSISTANT_IMPATIENCE_DURATION_MS,
+  ASSISTANT_JUMP_DURATION_MS,
+  ASSISTANT_WAKE_DURATION_MS,
+  AssistantComponent
+} from './assistant.component';
 import { TranslationService } from '../../services/translation.service';
 import { MockTranslationService } from '../../testing/mock-translation.service';
 
@@ -23,10 +28,10 @@ describe('AssistantComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
     expect(component.isOpen).toBeFalse();
-    expect(component.animationPhase).toBe('idle');
+    expect(component.animationPhase).toBe('sleeping');
   });
 
-  it('should emit opened event and start wondering phase when opened', fakeAsync(() => {
+  it('should emit opened event and start waking phase when opened', fakeAsync(() => {
     const openedSpy = jasmine.createSpy('opened');
     component.opened.subscribe(openedSpy);
 
@@ -34,37 +39,50 @@ describe('AssistantComponent', () => {
     tick();
 
     expect(component.isOpen).toBeTrue();
-    expect(component.animationPhase).toBe('wondering');
+    expect(component.animationPhase).toBe('waking');
     expect(openedSpy).toHaveBeenCalled();
 
     component.closeAssistant();
     tick();
   }));
 
-  it('should transition from wondering to suggestClose after five seconds', fakeAsync(() => {
-    component.openAssistant();
-    expect(component.animationPhase).toBe('wondering');
-
-    tick(4999);
-    expect(component.animationPhase).toBe('wondering');
-
-    tick(1);
-    expect(component.animationPhase).toBe('suggestClose');
-  }));
-
-  it('should emit closed event and reset state when closed', fakeAsync(() => {
+  it('should transition through jump and impatience before returning to sleep', fakeAsync(() => {
     const closedSpy = jasmine.createSpy('closed');
     component.closed.subscribe(closedSpy);
 
     component.openAssistant();
-    tick(5000);
-    expect(component.animationPhase).toBe('suggestClose');
+    expect(component.animationPhase).toBe('waking');
 
+    tick(ASSISTANT_WAKE_DURATION_MS - 1);
+    expect(component.animationPhase).toBe('waking');
+
+    tick(1);
+    expect(component.animationPhase).toBe('jumping');
+
+    tick(ASSISTANT_JUMP_DURATION_MS);
+    expect(component.animationPhase).toBe('impatient');
+    expect(component.isOpen).toBeTrue();
+
+    tick(ASSISTANT_IMPATIENCE_DURATION_MS - 1);
+    expect(component.animationPhase).toBe('impatient');
+
+    tick(1);
+    expect(component.animationPhase).toBe('sleeping');
+    expect(component.isOpen).toBeFalse();
+    expect(closedSpy).toHaveBeenCalledTimes(1);
+  }));
+
+  it('should emit closed event and reset state when closed manually', fakeAsync(() => {
+    const closedSpy = jasmine.createSpy('closed');
+    component.closed.subscribe(closedSpy);
+
+    component.openAssistant();
+    tick(ASSISTANT_WAKE_DURATION_MS + 50);
     component.closeAssistant();
     tick();
 
     expect(component.isOpen).toBeFalse();
-    expect(component.animationPhase).toBe('idle');
+    expect(component.animationPhase).toBe('sleeping');
     expect(closedSpy).toHaveBeenCalled();
   }));
 });


### PR DESCRIPTION
## Summary
- add explicit sleeping, waking, jumping, and impatient states to the assistant component with coordinated timers
- restyle the assistant markup and animations to reflect the new behavioural stages and eye movements
- update unit tests to cover the revised timing sequence and automatic sleep reset

## Testing
- npm run build *(fails: ng not found because dependencies cannot be installed in this environment)*
- npm run test *(fails: ng not found because dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e422accd68832b921c8d4234656d29