### PR TITLE
Fix About section hover and dark theme styling

### DIFF
--- a/src/app/components/about/about.component.scss
+++ b/src/app/components/about/about.component.scss
@@ -4,6 +4,24 @@
     --about-card-bg: rgba(15, 23, 42, 0.06);
     --about-card-border: rgba(99, 102, 241, 0.22);
     --about-text-muted: rgba(15, 23, 42, 0.7);
+    --about-body-text: rgba(15, 23, 42, 0.9);
+    --about-highlight-bg: rgba(99, 102, 241, 0.08);
+    --about-highlight-border: rgba(99, 102, 241, 0.25);
+    --about-highlight-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+    --about-section-bg: linear-gradient(160deg, rgba(99, 102, 241, 0.08), rgba(79, 70, 229, 0));
+}
+
+:host-context(body.dark-mode) {
+    --about-accent: #818cf8;
+    --about-accent-soft: rgba(129, 140, 248, 0.24);
+    --about-card-bg: rgba(23, 24, 33, 0.75);
+    --about-card-border: rgba(129, 140, 248, 0.3);
+    --about-text-muted: rgba(226, 232, 240, 0.72);
+    --about-body-text: rgba(226, 232, 240, 0.88);
+    --about-highlight-bg: rgba(129, 140, 248, 0.16);
+    --about-highlight-border: rgba(129, 140, 248, 0.35);
+    --about-highlight-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.35);
+    --about-section-bg: linear-gradient(160deg, rgba(129, 140, 248, 0.14), rgba(79, 70, 229, 0.08));
 }
 
 .about-section {
@@ -14,7 +32,7 @@
     justify-content: center;
     align-items: center;
     padding: clamp(2.5rem, 6vw, 5rem) clamp(1.25rem, 5vw, 4rem);
-    background: linear-gradient(160deg, rgba(99, 102, 241, 0.08), rgba(79, 70, 229, 0));
+    background: var(--about-section-bg);
 }
 
 .about-container {
@@ -38,11 +56,6 @@
     pointer-events: none;
 }
 
-.about-container:not(.is-loading):hover {
-    transform: translateY(-6px);
-    box-shadow: 0 32px 65px rgba(15, 23, 42, 0.16);
-}
-
 .about-title {
     margin: 0;
     font-size: clamp(1.8rem, 3.5vw, 2.6rem);
@@ -55,7 +68,7 @@
     display: flex;
     flex-direction: column;
     gap: clamp(1rem, 2.5vw, 1.75rem);
-    color: rgba(15, 23, 42, 0.9);
+    color: var(--about-body-text);
     line-height: 1.65;
     align-items: center;
     text-align: center;
@@ -70,9 +83,9 @@
 .about-highlights {
     padding: clamp(1rem, 2vw, 1.5rem);
     border-radius: 18px;
-    background: rgba(99, 102, 241, 0.08);
-    border: 1px solid rgba(99, 102, 241, 0.25);
-    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+    background: var(--about-highlight-bg);
+    border: 1px solid var(--about-highlight-border);
+    box-shadow: var(--about-highlight-shadow);
     align-self: stretch;
     text-align: left;
 }


### PR DESCRIPTION
## Summary
- remove the hover lift effect from the About card so it no longer appears clickable
- add dark-mode specific CSS variables so the About highlights respect the dark theme palette

## Testing
- ⚠️ `npm install` *(fails with 403 Forbidden when downloading @angular/compiler-cli)*

------
https://chatgpt.com/codex/tasks/task_e_68e42cc62c90832ba603e1459d7e01a4