### PR TITLE
Fix assistant popup positioning and adjust navigator controls

### DIFF
--- a/src/app/components/assistant/assistant.component.scss
+++ b/src/app/components/assistant/assistant.component.scss
@@ -4,7 +4,6 @@
   --assistant-popup-width: min(320px, 82vw);
   display: block;
   position: relative;
-  width: var(--assistant-popup-width);
   max-width: 100%;
 }
 
@@ -22,6 +21,7 @@
   width: var(--assistant-avatar-size);
   height: var(--assistant-avatar-size);
   pointer-events: auto;
+  z-index: 3;
 }
 
 .assistant__avatar {
@@ -39,6 +39,7 @@
   box-shadow: 0 16px 30px rgba(0, 0, 0, 0.25);
   transition: box-shadow 0.35s ease;
   outline: none;
+  z-index: 3;
 }
 
 .assistant__avatar:focus-visible {
@@ -88,9 +89,8 @@
 
 .assistant__popup {
   position: absolute;
-  bottom: 0;
   right: 0;
-  transform: translateY(calc(-100% - var(--assistant-spacing)));
+  bottom: calc(100% + var(--assistant-spacing));
   width: var(--assistant-popup-width);
   max-width: 100%;
   background: rgba(22, 29, 49, 0.92);

--- a/src/app/components/navigator/navigator.component.html
+++ b/src/app/components/navigator/navigator.component.html
@@ -63,7 +63,7 @@
       </div>
     </ng-container>
 
-    <button class="nav-button close-button" (click)="toggleNavigator()"
+    <button class="nav-button close-button nav-toggle-button" (click)="toggleNavigator()"
       [attr.aria-label]="getToggleButtonLabel()"
       [matTooltip]="getToggleButtonLabel()" matTooltipPosition="left"
       [attr.aria-expanded]="isOpen">

--- a/src/app/components/navigator/navigator.component.html
+++ b/src/app/components/navigator/navigator.component.html
@@ -1,77 +1,73 @@
-<div class="navigator-wrapper">
-  <!-- Toggle button always available -->
-  <button class="nav-toggle-button" (click)="toggleNavigator()"
-    [attr.aria-expanded]="isOpen"
-    [attr.aria-label]="isOpen ? 'Chiudi navigatore' : 'Apri navigatore'">
-    <mat-icon>{{ isOpen ? 'expand_more' : 'expand_less' }}</mat-icon>
-  </button>
-
+<div class="navigator-wrapper" [class.navigator-wrapper--collapsed]="!isOpen">
   <!-- Modern, animated, circular floating navbar -->
-  <div class="modern-navigator" *ngIf="isOpen">
-    <div class="arrow-container">
-      <!-- Previous button -->
-      <button class="arrow-button" *ngIf="currentSectionIndex > 0" (click)="onPrevious()" aria-label="Sezione precedente"
-        [matTooltip]="getTooltip('prev')" matTooltipPosition="left">
-        <mat-icon>arrow_upward</mat-icon>
-      </button>
+  <div class="modern-navigator" [class.modern-navigator--collapsed]="!isOpen">
+    <ng-container *ngIf="isOpen">
+      <div class="arrow-container">
+        <!-- Previous button -->
+        <button class="arrow-button" *ngIf="currentSectionIndex > 0" (click)="onPrevious()" aria-label="Sezione precedente"
+          [matTooltip]="getTooltip('prev')" matTooltipPosition="left">
+          <mat-icon>arrow_upward</mat-icon>
+        </button>
 
-      <!-- Next button -->
-      <button class="arrow-button" *ngIf="currentSectionIndex < totalSections - 1" (click)="onNext()" aria-label="Sezione successiva"
-        [matTooltip]="getTooltip('next')" matTooltipPosition="left">
-        <mat-icon>arrow_downward</mat-icon>
-      </button>
-    </div>
-
-    <div class="nav-group">
-      <button class="nav-button" (click)="toggleThemeOptions()" aria-label="Selettore tema"
-        [matTooltip]="getTooltip('theme')" matTooltipPosition="left">
-        <mat-icon>{{ getThemeIcon(currentTheme) }}</mat-icon>
-      </button>
-      <div class="option-container" *ngIf="showThemeOptions">
-        <button class="option-button" (click)="changeTheme('light')" aria-label="Tema chiaro"
-          [class.selected]="currentTheme === 'light'">
-          <mat-icon>light_mode</mat-icon>
-        </button>
-        <button class="option-button" (click)="changeTheme('dark')" aria-label="Tema scuro"
-          [class.selected]="currentTheme === 'dark'">
-          <mat-icon>dark_mode</mat-icon>
-        </button>
-        <button class="option-button" (click)="changeTheme('blue')" aria-label="Tema blu"
-          [class.selected]="currentTheme === 'blue'">
-          <mat-icon>water_drop</mat-icon>
-        </button>
-        <button class="option-button" (click)="changeTheme('green')" aria-label="Tema verde"
-          [class.selected]="currentTheme === 'green'">
-          <mat-icon>eco</mat-icon>
+        <!-- Next button -->
+        <button class="arrow-button" *ngIf="currentSectionIndex < totalSections - 1" (click)="onNext()" aria-label="Sezione successiva"
+          [matTooltip]="getTooltip('next')" matTooltipPosition="left">
+          <mat-icon>arrow_downward</mat-icon>
         </button>
       </div>
-    </div>
 
-    <div class="nav-group">
-      <button class="nav-button" (click)="toggleLanguageOptions()" [matTooltip]="getTooltip('language')"
-        matTooltipPosition="left">
-        <span class="lang-label">{{ currentLang | slice:0:3 | uppercase }}</span>
-      </button>
-      <div class="option-container" *ngIf="showLanguageOptions">
-        <button class="option-button" (click)="changeLanguage('en')" aria-label="Inglese">
-          <span class="lang-flag">🇬🇧</span>
+      <div class="nav-group">
+        <button class="nav-button" (click)="toggleThemeOptions()" aria-label="Selettore tema"
+          [matTooltip]="getTooltip('theme')" matTooltipPosition="left">
+          <mat-icon>{{ getThemeIcon(currentTheme) }}</mat-icon>
         </button>
-        <button class="option-button" (click)="changeLanguage('it')" aria-label="Italiano">
-          <span class="lang-flag">🇮🇹</span>
-        </button>
-        <button class="option-button" (click)="changeLanguage('de')" aria-label="Tedesco">
-          <span class="lang-flag">🇩🇪</span>
-        </button>
-        <button class="option-button" (click)="changeLanguage('es')" aria-label="Spagnolo">
-          <span class="lang-flag">🇪🇸</span>
-        </button>
+        <div class="option-container" *ngIf="showThemeOptions">
+          <button class="option-button" (click)="changeTheme('light')" aria-label="Tema chiaro"
+            [class.selected]="currentTheme === 'light'">
+            <mat-icon>light_mode</mat-icon>
+          </button>
+          <button class="option-button" (click)="changeTheme('dark')" aria-label="Tema scuro"
+            [class.selected]="currentTheme === 'dark'">
+            <mat-icon>dark_mode</mat-icon>
+          </button>
+          <button class="option-button" (click)="changeTheme('blue')" aria-label="Tema blu"
+            [class.selected]="currentTheme === 'blue'">
+            <mat-icon>water_drop</mat-icon>
+          </button>
+          <button class="option-button" (click)="changeTheme('green')" aria-label="Tema verde"
+            [class.selected]="currentTheme === 'green'">
+            <mat-icon>eco</mat-icon>
+          </button>
+        </div>
       </div>
-    </div>
 
-    <button class="nav-button close-button" (click)="closeNavigator()"
-      [attr.aria-label]="getCloseButtonLabel()"
-      [matTooltip]="getCloseButtonLabel()" matTooltipPosition="left">
-      <mat-icon>close</mat-icon>
+      <div class="nav-group">
+        <button class="nav-button" (click)="toggleLanguageOptions()" [matTooltip]="getTooltip('language')"
+          matTooltipPosition="left">
+          <span class="lang-label">{{ currentLang | slice:0:3 | uppercase }}</span>
+        </button>
+        <div class="option-container" *ngIf="showLanguageOptions">
+          <button class="option-button" (click)="changeLanguage('en')" aria-label="Inglese">
+            <span class="lang-flag">🇬🇧</span>
+          </button>
+          <button class="option-button" (click)="changeLanguage('it')" aria-label="Italiano">
+            <span class="lang-flag">🇮🇹</span>
+          </button>
+          <button class="option-button" (click)="changeLanguage('de')" aria-label="Tedesco">
+            <span class="lang-flag">🇩🇪</span>
+          </button>
+          <button class="option-button" (click)="changeLanguage('es')" aria-label="Spagnolo">
+            <span class="lang-flag">🇪🇸</span>
+          </button>
+        </div>
+      </div>
+    </ng-container>
+
+    <button class="nav-button close-button" (click)="toggleNavigator()"
+      [attr.aria-label]="getToggleButtonLabel()"
+      [matTooltip]="getToggleButtonLabel()" matTooltipPosition="left"
+      [attr.aria-expanded]="isOpen">
+      <mat-icon>expand_more</mat-icon>
     </button>
   </div>
 </div>

--- a/src/app/components/navigator/navigator.component.scss
+++ b/src/app/components/navigator/navigator.component.scss
@@ -122,6 +122,10 @@ $navigator-themes: (
     gap: 12px;
     align-items: center;
 
+    &.modern-navigator--collapsed {
+        gap: 0;
+    }
+
     .arrow-container {
         width: $navigator-button-size - 8;
         justify-content: center;
@@ -157,6 +161,7 @@ $navigator-themes: (
         mat-icon {
             font-size: $navigator-icon-size;
             color: var(--navigator-icon-color);
+            transition: transform 0.25s ease;
         }
 
         .lang-label {
@@ -167,10 +172,6 @@ $navigator-themes: (
 
         &.close-button {
             margin-top: 4px;
-
-            mat-icon {
-                font-size: $navigator-icon-size;
-            }
         }
     }
 
@@ -193,6 +194,16 @@ $navigator-themes: (
             font-size: $navigator-icon-size;
             color: var(--navigator-icon-color);
             position: absolute;
+        }
+    }
+
+    &.modern-navigator--collapsed {
+        .close-button {
+            margin-top: 0;
+
+            mat-icon {
+                transform: rotate(180deg);
+            }
         }
     }
 }

--- a/src/app/components/navigator/navigator.component.ts
+++ b/src/app/components/navigator/navigator.component.ts
@@ -28,7 +28,7 @@ export class NavigatorComponent implements OnInit {
   currentTheme: 'light' | 'dark' | 'blue' | 'green' = 'light';
 
   /** Controls visibility of the navigator */
-  isOpen = false;
+  isOpen = true;
 
   /** Tracks whether the current scroll was triggered programmatically */
   private programmaticScroll = false;
@@ -62,11 +62,11 @@ export class NavigatorComponent implements OnInit {
     }
   };
 
-  closeButtonLabels: { [key: string]: string } = {
-    en: 'Close navigator',
-    it: 'Chiudi navigatore',
-    de: 'Navigator schließen',
-    es: 'Cerrar navegador'
+  toggleButtonLabels: { [key: string]: { open: string; close: string } } = {
+    en: { open: 'Open navigator', close: 'Close navigator' },
+    it: { open: 'Apri navigatore', close: 'Chiudi navigatore' },
+    de: { open: 'Navigator öffnen', close: 'Navigator schließen' },
+    es: { open: 'Abrir navegador', close: 'Cerrar navegador' }
   };
 
   constructor(
@@ -137,8 +137,9 @@ export class NavigatorComponent implements OnInit {
     return this.tooltipTexts[this.currentLang][key];
   }
 
-  getCloseButtonLabel(): string {
-    return this.closeButtonLabels[this.currentLang] || this.closeButtonLabels['en'];
+  getToggleButtonLabel(): string {
+    const labels = this.toggleButtonLabels[this.currentLang] || this.toggleButtonLabels['en'];
+    return this.isOpen ? labels.close : labels.open;
   }
 
   private applyTheme(theme: 'light' | 'dark' | 'blue' | 'green'): void {

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -9,10 +9,10 @@
   <div #section><app-contact-me></app-contact-me></div>
 
   <div class="home__floating-controls" [class.home__floating-controls--assistant-open]="isAssistantOpen">
+    <app-assistant (opened)="onAssistantOpened()" (closed)="onAssistantClosed()"></app-assistant>
+
     <app-navigator [totalSections]="totalSections" [currentSectionIndex]="currentSectionIndex"
       (navigateNext)="navigateNext()" (navigatePrevious)="navigatePrevious()">
     </app-navigator>
-
-    <app-assistant (opened)="onAssistantOpened()" (closed)="onAssistantClosed()"></app-assistant>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- ensure the assistant component renders before the navigator so the navbar appears to the right of the assistant
- anchor the assistant popup directly to the avatar and raise the avatar stacking order so it overlaps the dialog
- replace the floating navigator toggle button with the integrated arrow control, update labels, and tweak collapsed styling

## Testing
- npm install *(fails: 403 Forbidden fetching @angular/compiler-cli)*

------
https://chatgpt.com/codex/tasks/task_e_68e42dae4e34832ba544dad857f6cd1a