### PR TITLE
Simplify tech stack display

### DIFF
--- a/src/app/components/skills/skills.component.html
+++ b/src/app/components/skills/skills.component.html
@@ -52,23 +52,19 @@
                   <h3 class="spotlight-title">{{ panel.title }}</h3>
                   <p class="spotlight-subtitle" *ngIf="panel.subtitle">{{ panel.subtitle }}</p>
                 </div>
-                <span class="spotlight-badge">{{ panel.badge }}</span>
               </header>
               <div class="spotlight-icons" role="list">
-                <button
+                <div
                   *ngFor="let skill of panel.skills"
-                  type="button"
                   class="skill-icon"
                   role="listitem"
                   data-skill-host
-                  (click)="onSkillClick($event, skill)"
-                  [class.clicked]="skill.clicked"
+                  [attr.aria-label]="skill.name"
                 >
                   <span class="icon-asset">
                     <img [src]="skill.icon" [alt]="skill.name" />
                   </span>
-                  <span class="icon-label">{{ skill.name }}</span>
-                </button>
+                </div>
               </div>
             </div>
           </div>
@@ -122,23 +118,19 @@
                 <h3 class="spotlight-title">{{ panel.title }}</h3>
                 <p class="spotlight-subtitle" *ngIf="panel.subtitle">{{ panel.subtitle }}</p>
               </div>
-              <span class="spotlight-badge">{{ panel.badge }}</span>
             </header>
             <div class="spotlight-icons" role="list">
-              <button
+              <div
                 *ngFor="let skill of panel.skills"
-                type="button"
                 class="skill-icon"
                 role="listitem"
                 data-skill-host
-                (click)="onSkillClick($event, skill)"
-                [class.clicked]="skill.clicked"
+                [attr.aria-label]="skill.name"
               >
                 <span class="icon-asset">
                   <img [src]="skill.icon" [alt]="skill.name" />
                 </span>
-                <span class="icon-label">{{ skill.name }}</span>
-              </button>
+              </div>
             </div>
           </div>
         </article>

--- a/src/app/components/skills/skills.component.scss
+++ b/src/app/components/skills/skills.component.scss
@@ -3,7 +3,6 @@
   --skills-accent-soft: rgba(99, 102, 241, 0.18);
   --skills-card-bg: rgba(15, 23, 42, 0.05);
   --skills-card-border: rgba(99, 102, 241, 0.28);
-  --skills-badge-bg: rgba(99, 102, 241, 0.16);
   --skills-text-muted: rgba(15, 23, 42, 0.65);
   --skills-section-bg: linear-gradient(160deg, rgba(99, 102, 241, 0.1), rgba(59, 130, 246, 0.04));
   --skills-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
@@ -14,7 +13,6 @@
   --skills-accent-soft: rgba(129, 140, 248, 0.24);
   --skills-card-bg: rgba(30, 31, 38, 0.7);
   --skills-card-border: rgba(129, 140, 248, 0.35);
-  --skills-badge-bg: rgba(129, 140, 248, 0.2);
   --skills-text-muted: rgba(226, 232, 240, 0.7);
   --skills-section-bg: linear-gradient(160deg, rgba(129, 140, 248, 0.16), rgba(79, 70, 229, 0.08));
   --skills-shadow: 0 20px 45px rgba(15, 23, 42, 0.25);
@@ -202,7 +200,7 @@
 .spotlight-header {
   display: flex;
   flex-wrap: wrap;
-  justify-content: space-between;
+  justify-content: flex-start;
   align-items: flex-start;
   gap: 0.75rem;
 }
@@ -233,22 +231,6 @@
   color: var(--skills-text-muted);
 }
 
-.spotlight-badge {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.35rem 0.85rem;
-  border-radius: 999px;
-  background: var(--skills-badge-bg);
-  color: var(--skills-accent);
-  font-weight: 600;
-  font-size: 0.85rem;
-  letter-spacing: 0.02em;
-}
-
-:host-context(body.dark-mode) .spotlight-badge {
-  color: #e0e7ff;
-}
-
 .spotlight-icons {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
@@ -256,30 +238,9 @@
 }
 
 .skill-icon {
-  position: relative;
   display: flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 0.5rem;
-  padding: 0.65rem;
-  border-radius: 16px;
-  border: 1px solid rgba(99, 102, 241, 0.25);
-  background: rgba(255, 255, 255, 0.65);
-  cursor: pointer;
-  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
-}
-
-:host-context(body.dark-mode) .skill-icon {
-  background: rgba(30, 31, 38, 0.8);
-  border-color: rgba(129, 140, 248, 0.4);
-}
-
-.skill-icon:hover,
-.skill-icon.clicked {
-  transform: translateY(-4px);
-  box-shadow: 0 15px 35px rgba(99, 102, 241, 0.25);
-  border-color: rgba(99, 102, 241, 0.6);
 }
 
 .icon-asset {
@@ -287,20 +248,12 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0.25rem;
 }
 
 .icon-asset img {
   width: 100%;
   max-height: 42px;
   object-fit: contain;
-}
-
-.icon-label {
-  font-size: 0.75rem;
-  font-weight: 600;
-  text-align: center;
-  color: var(--skills-text-muted);
 }
 
 @media (max-width: 1200px) {

--- a/src/app/components/skills/skills.component.spec.ts
+++ b/src/app/components/skills/skills.component.spec.ts
@@ -95,34 +95,4 @@ describe('SkillsComponent', () => {
     expect(component.currentIndex).toBe(panels.length - 1);
   });
 
-  it('should toggle the "clicked" state when a skill is clicked', () => {
-    const skill = component.sections[0].skills[0];
-    const initialState = skill.clicked;
-    component.onSkillClick(new MouseEvent('click'), skill);
-    expect(skill.clicked).toBe(!initialState); // "clicked" should toggle between true/false
-  });
-
-  it('should show popup message when a skill is clicked', () => {
-    const skill = component.sections[0].skills[0];
-    const parentElement = document.createElement('div');
-    const targetElement = document.createElement('button');
-    parentElement.appendChild(targetElement);
-    const event = { currentTarget: targetElement } as unknown as MouseEvent;
-    const popupSpy = spyOn(component, 'createPopupMessage').and.callThrough();
-
-    component.onSkillClick(event, skill);
-
-    expect(popupSpy).toHaveBeenCalledWith(targetElement);
-    expect(parentElement.querySelector('.popup')).toBeTruthy();
-  });
-
-  it('should guard against missing event targets when creating popup', () => {
-    const skill = component.sections[0].skills[0];
-    const event = { currentTarget: null, target: null } as unknown as MouseEvent;
-    const popupSpy = spyOn(component, 'createPopupMessage');
-
-    component.onSkillClick(event, skill);
-
-    expect(popupSpy).not.toHaveBeenCalled();
-  });
 });

--- a/src/app/components/skills/skills.component.ts
+++ b/src/app/components/skills/skills.component.ts
@@ -16,7 +16,6 @@ interface SkillTab {
 
 interface SpotlightPanel extends SkillSection {
   subtitle: string;
-  badge: string;
 }
 
 @Component({
@@ -72,30 +71,6 @@ export class SkillsComponent implements OnInit, OnDestroy {
       de: 'Tooling & Ops',
       es: 'Tooling y Ops',
       default: 'Tooling'
-    }
-  };
-
-  private readonly periodBadgeDictionary: Record<SkillTabId, Record<LanguageCode | 'default', string[]>> = {
-    backend: {
-      it: ['2014 → oggi', '2016 → oggi', '2018 → oggi', '2020 → oggi'],
-      en: ['2014 → now', '2016 → now', '2018 → now', '2020 → now'],
-      de: ['2014 → heute', '2016 → heute', '2018 → heute', '2020 → heute'],
-      es: ['2014 → hoy', '2016 → hoy', '2018 → hoy', '2020 → hoy'],
-      default: ['Ongoing expertise']
-    },
-    frontend: {
-      it: ['2012 → oggi', '2015 → oggi', '2017 → oggi'],
-      en: ['2012 → now', '2015 → now', '2017 → now'],
-      de: ['2012 → heute', '2015 → heute', '2017 → heute'],
-      es: ['2012 → hoy', '2015 → hoy', '2017 → hoy'],
-      default: ['Active expertise']
-    },
-    tooling: {
-      it: ['2013 → oggi', '2016 → oggi', '2018 → oggi', '2021 → oggi'],
-      en: ['2013 → now', '2016 → now', '2018 → now', '2021 → now'],
-      de: ['2013 → heute', '2016 → heute', '2018 → heute', '2021 → heute'],
-      es: ['2013 → hoy', '2016 → hoy', '2018 → hoy', '2021 → hoy'],
-      default: ['Continuous enablement']
     }
   };
 
@@ -189,72 +164,6 @@ export class SkillsComponent implements OnInit, OnDestroy {
     this.currentIndex = (this.currentIndex - 1 + items.length) % items.length;
   }
 
-  onSkillClick(event: MouseEvent, skill: SkillItem): void {
-    if (!this.isBrowser) return;
-
-    skill.clicked = !skill.clicked;
-
-    if (!skill.clicked) {
-      return;
-    }
-
-    const resolvedTarget = (event.currentTarget ?? event.target) as EventTarget | null;
-
-    if (!(resolvedTarget instanceof Element)) {
-      console.warn('Skill click target is not an HTMLElement.');
-      return;
-    }
-
-    const message = this.createPopupMessage(resolvedTarget);
-    if (message) {
-      setTimeout(() => message.remove(), 5000);
-    }
-  }
-
-  createPopupMessage(targetElement: Element): HTMLElement | null {
-    const message = document.createElement('div');
-    message.classList.add('popup');
-    message.style.cssText = `
-      position: absolute;
-      top: 10px;
-      left: 50%;
-      transform: translateX(-50%);
-      font-size: 1.2rem;
-      font-weight: bold;
-      z-index: 10;
-      text-align: center;
-      padding: 10px;
-      border-radius: 10px;
-    `;
-
-    const host = this.resolvePopupHost(targetElement);
-
-    if (!host) {
-      console.warn('Unable to attach popup message: host element not found.');
-      return null;
-    }
-
-    if (host instanceof HTMLElement && getComputedStyle(host).position === 'static') {
-      host.style.position = 'relative';
-    }
-
-    host.appendChild(message);
-    return message;
-  }
-
-  private resolvePopupHost(targetElement: Element): Element | null {
-    const timelineHost = targetElement.closest('.skill-chip, .skill-item, [data-skill-host]');
-    if (timelineHost) {
-      return timelineHost;
-    }
-
-    if (targetElement.parentElement) {
-      return targetElement.parentElement;
-    }
-
-    return targetElement instanceof HTMLElement ? targetElement : null;
-  }
-
   private resetCarouselIndex(): void {
     const items = this.getCarouselItems();
     const length = items.length;
@@ -301,11 +210,9 @@ export class SkillsComponent implements OnInit, OnDestroy {
 
     sections.forEach(section => {
       const groupId = this.resolveGroupId(section.title);
-      const badge = this.resolveBadge(groupId, groups[groupId].length);
       const panel: SpotlightPanel = {
         ...section,
-        subtitle: section.subtitle ?? '',
-        badge
+        subtitle: section.subtitle ?? ''
       };
 
       groups[groupId].push(panel);
@@ -332,20 +239,6 @@ export class SkillsComponent implements OnInit, OnDestroy {
       .toLowerCase()
       .normalize('NFD')
       .replace(/[\u0300-\u036f]/g, '');
-  }
-
-  private resolveBadge(groupId: SkillTabId, index: number): string {
-    const dictionary = this.periodBadgeDictionary[groupId];
-    const localized = dictionary[this.currentLanguage] ?? dictionary['default'];
-    const safeLocalized = localized.length ? localized : dictionary['default'];
-    const resolved = safeLocalized[Math.min(index, safeLocalized.length - 1)];
-
-    if (resolved) {
-      return resolved;
-    }
-
-    const fallback = dictionary['default'];
-    return fallback[Math.min(index, fallback.length - 1)] ?? '';
   }
 
   private buildTabs(): void {


### PR DESCRIPTION
## Summary
- remove the dated badge elements from the tech stack spotlight panels
- present each technology badge without duplicate inner cards and drop the unused popup behavior

## Testing
- not run (npm registry returned 403 during install)

------
https://chatgpt.com/codex/tasks/task_e_68e42f56c9f8832bb094349b21cbdcf9