### PR TITLE
Adjust education timeline alignment and layout

### DIFF
--- a/src/app/components/education/education.component.html
+++ b/src/app/components/education/education.component.html
@@ -1,22 +1,24 @@
 <section class="education-section" *ngIf="!isLoading">
-  <h2 class="education-title">{{ educationList.title }}</h2>
-  <div class="timeline" role="list">
-    <article
-      class="timeline-item"
-      role="listitem"
-      *ngFor="let education of educationList.education; let last = last"
-    >
-      <div class="timeline-marker" [class.is-last]="last">
-        <span class="timeline-dot" aria-hidden="true"></span>
-      </div>
-      <div class="timeline-card">
-        <header class="timeline-header">
-          <h3 class="timeline-heading">{{ education.title }}</h3>
-          <span class="timeline-badge">{{ education.startDate }} - {{ education.endDate }}</span>
-        </header>
-        <p class="timeline-institution">{{ education.institution }}</p>
-        <p class="timeline-description">{{ education.description }}</p>
-      </div>
-    </article>
+  <div class="education-content">
+    <h2 class="education-title">{{ educationList.title }}</h2>
+    <div class="timeline" role="list">
+      <article
+        class="timeline-item"
+        role="listitem"
+        *ngFor="let education of educationList.education; let last = last"
+      >
+        <div class="timeline-marker" [class.is-last]="last">
+          <span class="timeline-dot" aria-hidden="true"></span>
+        </div>
+        <div class="timeline-card">
+          <header class="timeline-header">
+            <h3 class="timeline-heading">{{ education.title }}</h3>
+            <span class="timeline-badge">{{ education.startDate }} - {{ education.endDate }}</span>
+          </header>
+          <p class="timeline-institution">{{ education.institution }}</p>
+          <p class="timeline-description">{{ education.description }}</p>
+        </div>
+      </article>
+    </div>
   </div>
 </section>

--- a/src/app/components/education/education.component.scss
+++ b/src/app/components/education/education.component.scss
@@ -8,6 +8,8 @@
   --timeline-heading-color: #0f172a;
   --timeline-description-color: rgba(15, 23, 42, 0.82);
   --timeline-section-bg: linear-gradient(160deg, rgba(99, 102, 241, 0.08), rgba(79, 70, 229, 0));
+  --timeline-card-padding: clamp(1.25rem, 3vw, 2rem);
+  --timeline-heading-offset: clamp(0.5rem, 1.2vw, 0.65rem);
 }
 
 :host-context(body.dark-mode) {
@@ -28,7 +30,15 @@
   flex-direction: column;
   align-items: center;
   background: var(--timeline-section-bg);
-  width: min(95vw, 100%);
+  width: 100%;
+}
+
+.education-content {
+  width: min(80vw, 1200px);
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .education-title {
@@ -41,7 +51,6 @@
 .timeline {
   --timeline-gap: clamp(1.75rem, 3vw, 2.75rem);
   width: 100%;
-  max-width: 960px;
   display: grid;
   gap: var(--timeline-gap);
   margin: 0 auto;
@@ -60,7 +69,9 @@
   justify-content: center;
   align-items: flex-start;
   align-self: stretch;
-  padding-top: clamp(0.15rem, 0.35vw, 0.35rem);
+  padding-top: calc(
+    var(--timeline-card-padding) + var(--timeline-heading-offset) - var(--timeline-dot-size) / 2
+  );
 }
 
 .timeline-marker::before {
@@ -80,7 +91,7 @@
 }
 
 .timeline-dot {
-  margin-top: clamp(0.25rem, 0.8vw, 0.45rem);
+  margin-top: 0;
   width: var(--timeline-dot-size);
   height: var(--timeline-dot-size);
   border-radius: 50%;
@@ -92,7 +103,7 @@
   background: linear-gradient(135deg, var(--timeline-card-bg), rgba(99, 102, 241, 0.1));
   border: 1px solid var(--timeline-card-border);
   border-radius: 18px;
-  padding: clamp(1.25rem, 3vw, 2rem);
+  padding: var(--timeline-card-padding);
   box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
   backdrop-filter: blur(6px);
   display: flex;
@@ -114,6 +125,7 @@
   font-weight: 600;
   text-align: left;
   color: var(--timeline-heading-color);
+  line-height: 1.3;
 }
 
 .timeline-badge {
@@ -146,6 +158,10 @@
     width: 100%;
   }
 
+  .education-content {
+    width: 100%;
+  }
+
   .timeline-item {
     grid-template-columns: 2.75rem 1fr;
   }
@@ -158,6 +174,9 @@
 @media (max-width: 600px) {
   .education-section {
     padding: clamp(2rem, 6vw, 3.5rem) clamp(1rem, 4vw, 2rem);
+  }
+
+  .education-content {
     width: 100%;
   }
 
@@ -170,7 +189,10 @@
 
   .timeline-marker {
     position: absolute;
-    inset: 1rem auto auto 0;
+    inset: calc(
+        var(--timeline-card-padding) + var(--timeline-heading-offset) - var(--timeline-dot-size) / 2
+      )
+      auto auto 0;
     width: 2.5rem;
     padding-top: 0;
   }
@@ -181,12 +203,12 @@
   }
 
   .timeline-dot {
-    margin-top: 0.1rem;
+    margin-top: 0;
   }
 }
 
 @media (min-width: 992px) {
-  .education-section {
+  .education-content {
     width: min(80vw, 1200px);
   }
 }


### PR DESCRIPTION
## Summary
- center the education timeline markers with the card titles for improved alignment
- expand the education section background to span the full viewport while constraining the inner content to 80% width

## Testing
- npm install *(fails: 403 Forbidden - GET https://registry.npmjs.org/@angular%2fcompiler-cli)*

------
https://chatgpt.com/codex/tasks/task_e_68e43063bc30832ba5b1f41d8f4abdab