### PR TITLE
Align experience section with app themes

### DIFF
--- a/src/app/components/experiences/experiences.component.scss
+++ b/src/app/components/experiences/experiences.component.scss
@@ -1,9 +1,47 @@
 :host {
-  --timeline-accent: #f97316;
-  --timeline-accent-soft: rgba(249, 115, 22, 0.18);
-  --timeline-card-bg: rgba(15, 23, 42, 0.05);
-  --timeline-card-border: rgba(249, 115, 22, 0.25);
-  --timeline-text-muted: rgba(15, 23, 42, 0.65);
+  --experience-accent: #14b8a6;
+  --experience-accent-soft: rgba(20, 184, 166, 0.18);
+  --experience-card-bg: rgba(15, 23, 42, 0.05);
+  --experience-card-highlight: rgba(255, 255, 255, 0.65);
+  --experience-card-border: rgba(20, 184, 166, 0.3);
+  --experience-card-shadow: 0 22px 55px rgba(15, 23, 42, 0.14);
+  --experience-text-muted: rgba(15, 23, 42, 0.68);
+  --experience-heading-color: #0f172a;
+  --experience-summary-color: rgba(15, 23, 42, 0.85);
+  --experience-section-bg: linear-gradient(160deg, rgba(20, 184, 166, 0.12), rgba(20, 184, 166, 0));
+  --experience-badge-bg: rgba(20, 184, 166, 0.16);
+}
+
+:host-context(body.dark-mode) {
+  --experience-accent: #2dd4bf;
+  --experience-accent-soft: rgba(45, 212, 191, 0.24);
+  --experience-card-bg: rgba(30, 31, 38, 0.75);
+  --experience-card-highlight: rgba(13, 148, 136, 0.12);
+  --experience-card-border: rgba(45, 212, 191, 0.38);
+  --experience-card-shadow: 0 24px 55px rgba(15, 23, 42, 0.35);
+  --experience-text-muted: rgba(226, 232, 240, 0.7);
+  --experience-heading-color: #e2e8f0;
+  --experience-summary-color: rgba(226, 232, 240, 0.86);
+  --experience-section-bg: linear-gradient(160deg, rgba(45, 212, 191, 0.18), rgba(13, 148, 136, 0.08));
+  --experience-badge-bg: rgba(13, 148, 136, 0.25);
+}
+
+:host-context(body.blue-mode) {
+  --experience-accent: #2563eb;
+  --experience-accent-soft: rgba(37, 99, 235, 0.22);
+  --experience-card-highlight: rgba(37, 99, 235, 0.14);
+  --experience-card-border: rgba(37, 99, 235, 0.32);
+  --experience-section-bg: linear-gradient(160deg, rgba(37, 99, 235, 0.12), rgba(37, 99, 235, 0));
+  --experience-badge-bg: rgba(37, 99, 235, 0.18);
+}
+
+:host-context(body.green-mode) {
+  --experience-accent: #0f9d58;
+  --experience-accent-soft: rgba(15, 157, 88, 0.2);
+  --experience-card-highlight: rgba(15, 157, 88, 0.14);
+  --experience-card-border: rgba(15, 157, 88, 0.32);
+  --experience-section-bg: linear-gradient(160deg, rgba(15, 157, 88, 0.16), rgba(15, 157, 88, 0));
+  --experience-badge-bg: rgba(15, 157, 88, 0.2);
 }
 
 .experiences-section {
@@ -12,11 +50,12 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  background: linear-gradient(160deg, rgba(249, 115, 22, 0.08), rgba(249, 115, 22, 0));
+  width: min(95vw, 100%);
+  background: var(--experience-section-bg);
 }
 
 .experiences-title {
-  font-size: clamp(1.8rem, 3vw, 2.4rem);
+  font-size: clamp(1.8rem, 3vw, 2.35rem);
   font-weight: 700;
   margin-bottom: clamp(2rem, 4vw, 3rem);
   text-align: center;
@@ -24,7 +63,8 @@
 
 .timeline {
   --timeline-gap: clamp(1.75rem, 3vw, 2.75rem);
-  width: min(80vw, 960px);
+  width: 100%;
+  max-width: 1024px;
   display: grid;
   gap: var(--timeline-gap);
   margin: 0 auto;
@@ -32,7 +72,7 @@
 
 .timeline-item {
   display: grid;
-  grid-template-columns: 3.5rem 1fr;
+  grid-template-columns: 3.25rem 1fr;
   column-gap: clamp(1.25rem, 2.5vw, 2rem);
   align-items: start;
 }
@@ -42,143 +82,158 @@
   display: flex;
   justify-content: center;
   align-items: flex-start;
+  align-self: stretch;
+  padding-top: clamp(0.15rem, 0.35vw, 0.35rem);
 }
 
 .timeline-marker::before {
   content: "";
   position: absolute;
-  top: 0.5rem;
+  top: 0.35rem;
   left: calc(50% - 1.5px);
   width: 3px;
-  bottom: calc(var(--timeline-gap) * -1);
-  background: linear-gradient(180deg, var(--timeline-accent), rgba(249, 115, 22, 0));
+  bottom: calc(var(--timeline-gap) * -1.05);
+  background: linear-gradient(180deg, var(--experience-accent), rgba(15, 23, 42, 0));
   border-radius: 999px;
 }
 
 .timeline-marker.is-last::before {
-  bottom: 0;
+  bottom: clamp(-1.25rem, -2.5vw, -0.65rem);
+  opacity: 0.7;
 }
 
 .timeline-dot {
-  margin-top: 0.25rem;
+  margin-top: clamp(0.25rem, 0.8vw, 0.45rem);
   width: 18px;
   height: 18px;
   border-radius: 50%;
-  background: var(--timeline-accent);
-  box-shadow: 0 0 0 6px var(--timeline-accent-soft), 0 10px 30px rgba(249, 115, 22, 0.18);
+  background: var(--experience-accent);
+  box-shadow: 0 0 0 6px var(--experience-accent-soft), 0 12px 32px rgba(15, 23, 42, 0.18);
 }
 
 .timeline-card {
-  background: linear-gradient(135deg, var(--timeline-card-bg), rgba(249, 115, 22, 0.1));
-  border: 1px solid var(--timeline-card-border);
-  border-radius: 18px;
-  padding: clamp(1.25rem, 3vw, 2rem);
-  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
+  position: relative;
+  background: linear-gradient(135deg, var(--experience-card-bg), var(--experience-card-highlight));
+  border: 1px solid var(--experience-card-border);
+  border-radius: 20px;
+  padding: clamp(1.35rem, 3vw, 2.15rem);
+  box-shadow: var(--experience-card-shadow);
   backdrop-filter: blur(6px);
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.85rem;
+  text-align: left;
+}
+
+.timeline-card::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 5px;
+  border-radius: 20px 0 0 20px;
+  background: linear-gradient(180deg, var(--experience-accent), rgba(15, 23, 42, 0));
 }
 
 .timeline-header {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
   gap: 0.75rem;
-  align-items: baseline;
+  align-items: start;
 }
 
 .timeline-heading {
   margin: 0;
-  font-size: clamp(1.1rem, 2.4vw, 1.4rem);
+  font-size: clamp(1.1rem, 2.4vw, 1.45rem);
   font-weight: 600;
+  color: var(--experience-heading-color);
 }
 
 .timeline-badge {
-  padding: 0.35rem 0.75rem;
+  justify-self: end;
+  padding: 0.35rem 0.85rem;
   border-radius: 999px;
-  background: rgba(249, 115, 22, 0.15);
-  color: var(--timeline-accent);
+  background: var(--experience-badge-bg);
+  color: var(--experience-accent);
   font-size: 0.85rem;
   font-weight: 600;
   letter-spacing: 0.02em;
+  white-space: nowrap;
 }
 
 .timeline-company {
   margin: 0;
   font-weight: 600;
-  color: rgba(15, 23, 42, 0.85);
+  color: var(--experience-heading-color);
 }
 
-.timeline-location {
+.timeline-location,
+.timeline-technologies {
   margin: 0;
   font-weight: 500;
-  color: var(--timeline-text-muted);
+  color: var(--experience-text-muted);
 }
 
 .timeline-technologies {
-  margin: 0;
   font-style: italic;
-  color: rgba(15, 23, 42, 0.7);
 }
 
 .timeline-summary {
   margin: 0;
-  line-height: 1.6;
-  color: rgba(15, 23, 42, 0.85);
+  line-height: 1.65;
+  color: var(--experience-summary-color);
 }
 
 .timeline-responsibilities {
   margin: 0;
   padding-left: 1.25rem;
   display: grid;
-  gap: 0.5rem;
-  color: rgba(15, 23, 42, 0.82);
+  gap: 0.55rem;
+  color: var(--experience-summary-color);
 }
 
 .timeline-responsibilities li {
   line-height: 1.55;
 }
 
-@media (max-width: 1200px) {
-  .timeline {
-    width: min(86vw, 960px);
-  }
-}
-
 @media (max-width: 992px) {
-  .timeline {
-    width: min(92vw, 960px);
+  .timeline-item {
+    grid-template-columns: 2.85rem 1fr;
   }
 
-  .timeline-item {
-    grid-template-columns: 3.1rem 1fr;
+  .timeline-header {
+    grid-template-columns: 1fr;
+  }
+
+  .timeline-badge {
+    justify-self: flex-start;
   }
 }
 
 @media (max-width: 768px) {
   .timeline {
     --timeline-gap: clamp(1.5rem, 4vw, 2rem);
+    width: 100%;
   }
 
   .timeline-item {
-    grid-template-columns: 2.75rem 1fr;
-  }
-
-  .timeline-badge {
-    font-size: 0.8rem;
+    grid-template-columns: 2.5rem 1fr;
   }
 }
 
 @media (max-width: 600px) {
   .experiences-section {
     padding: clamp(2rem, 6vw, 3.5rem) clamp(1rem, 4vw, 2rem);
+    width: 100%;
+  }
+
+  .timeline {
+    --timeline-gap: clamp(1.35rem, 4vw, 1.85rem);
   }
 
   .timeline-item {
     position: relative;
     grid-template-columns: 1fr;
-    row-gap: 1rem;
+    row-gap: 1.1rem;
     padding-left: 2.5rem;
   }
 
@@ -186,14 +241,15 @@
     position: absolute;
     inset: 1rem auto auto 0;
     width: 2.5rem;
+    padding-top: 0;
   }
 
   .timeline-marker::before {
     left: calc(1.25rem - 1.5px);
-    top: 0.75rem;
+    top: 0.4rem;
   }
 
   .timeline-dot {
-    margin-top: 0;
+    margin-top: 0.15rem;
   }
 }


### PR DESCRIPTION
## Summary
- add theme-aware design tokens for the experience timeline so the section follows active color schemes
- refine the experience cards with left-aligned content and a distinctive accent spine to differentiate them from education
- tune responsive breakpoints to keep badges and markers aligned on smaller screens

## Testing
- not run (npm install blocked by 403 from registry)


------
https://chatgpt.com/codex/tasks/task_e_68e430a49edc832bb8909c47169a2fa1