### PR TITLE
Align statistics section styling with theme palette

### DIFF
--- a/src/app/components/stats/stats.component.scss
+++ b/src/app/components/stats/stats.component.scss
@@ -1,137 +1,175 @@
 .statistics-component {
+    --stat-bg: linear-gradient(135deg, rgba(108, 99, 255, 0.1), rgba(59, 130, 246, 0.1), rgba(0, 191, 166, 0.12));
+    --stat-card-bg: rgba(255, 255, 255, 0.92);
+    --stat-card-border: rgba(148, 163, 184, 0.35);
+    --stat-icon-bg: rgba(59, 130, 246, 0.12);
+    --stat-icon-color: #2563eb;
+    --stat-label-color: #475569;
+    --stat-value-color: #0f172a;
+    --stat-title-color: #0f172a;
+
     min-height: 100vh;
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: center;
+    padding: 6rem 1.5rem;
+    position: relative;
+    background: var(--stat-bg);
+    isolation: isolate;
+
+    &::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background: inherit;
+        filter: blur(80px);
+        opacity: 0.55;
+        z-index: -1;
+    }
 
     .statistics-section {
         position: relative;
-
-        .statistics-overlay {
-            position: absolute;
-            inset: 0;
-            width: 100%;
-            height: 100%;
-        }
+        width: 100%;
+        max-width: 1320px;
 
         .statistics-container {
-            max-width: 1320px;
             margin: 0 auto;
-            padding: 0 15px;
+            padding: 0 1.5rem;
         }
 
         .statistics-row {
             display: flex;
             flex-wrap: wrap;
-            gap: 20px;
+            gap: 24px;
             justify-content: center;
         }
 
         .statistics-card {
-            border-radius: 8px;
-            padding: 20px;
+            background: var(--stat-card-bg);
+            border: 1px solid var(--stat-card-border);
+            border-radius: 20px;
+            padding: 32px 28px;
             text-align: center;
-            flex: 1 1 calc(25% - 20px);
+            flex: 1 1 calc(25% - 24px);
             min-width: 250px;
-            transition: transform 0.3s ease;
-            max-width: 300px;
+            max-width: 320px;
+            transition: transform 0.3s ease, box-shadow 0.3s ease;
+            box-shadow: 0 22px 45px -28px rgba(15, 23, 42, 0.45);
+            backdrop-filter: blur(12px);
 
             &:hover {
-                transform: translateY(-10px);
+                transform: translateY(-12px);
                 cursor: pointer;
+                box-shadow: 0 26px 60px -28px rgba(37, 99, 235, 0.4);
             }
 
             .statistics-content {
                 width: 100%;
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                gap: 0.75rem;
 
                 .statistics-icon {
-                    margin-bottom: 15px;
+                    display: inline-flex;
+                    align-items: center;
+                    justify-content: center;
+                    width: 68px;
+                    height: 68px;
+                    border-radius: 20px;
+                    background: var(--stat-icon-bg);
+                    color: var(--stat-icon-color);
+                    margin-bottom: 0.5rem;
 
                     mat-icon {
-                        font-size: 7vh;
-                        width: 100%;
-                        height: 100%;
+                        font-size: 3rem;
+                        width: 1em;
+                        height: 1em;
                     }
                 }
 
                 .statistics-value {
-                    font-size: 2rem;
+                    font-size: 2.15rem;
                     font-weight: 700;
-                    margin-bottom: 10px;
+                    color: var(--stat-value-color);
+                    margin: 0;
                 }
 
                 .statistics-label {
-                    font-size: 1.5rem;
-                    text-align: center;
+                    font-size: 1.15rem;
+                    color: var(--stat-label-color);
                     max-width: 100%;
+                    margin: 0;
                 }
             }
         }
 
-        .statistics-section-title {
-            font-size: 2.5rem;
+        .statistics-section-title,
+        h1 {
+            font-size: 2.75rem;
             font-weight: 600;
             text-align: center;
-            margin-bottom: 2rem;
-        }
-
-        h1{
-            margin-bottom: 24px;
+            margin-bottom: 3rem;
+            color: var(--stat-title-color);
         }
     }
 
     @media (max-width: 1200px) {
-        .statistics-card {
-            flex: 1 1 calc(33.33% - 20px);
-            max-width: 240px;
-            min-width: 220px;
+        .statistics-section {
+            .statistics-card {
+                flex: 1 1 calc(33.33% - 24px);
+                max-width: 280px;
+            }
         }
     }
 
     @media (max-width: 992px) {
-        .statistics-component{
-            padding: 0 !important;
-        }
+        padding: 4rem 1rem;
 
-        .statistics-card {
-            flex: 1 1 calc(50% - 20px);
-            max-width: 300px;
-            min-width: 200px;
+        .statistics-section {
+            .statistics-card {
+                flex: 1 1 calc(50% - 24px);
+                max-width: 320px;
+                min-width: 220px;
+            }
         }
     }
 
     @media (max-width: 768px) {
-        .statistics-component{
-            padding: 0 !important;
-        }
+        padding: 3rem 1rem;
 
-        .statistics-card {
-            flex: 1 1 100% !important;
-            max-width: 280px !important;
-            min-width: 180px !important;
-            padding: 10px !important;
-        }
+        .statistics-section {
+            .statistics-card {
+                flex: 1 1 100%;
+                max-width: 320px;
+                min-width: 200px;
+                padding: 24px 20px;
+            }
 
-        h2{
-            font-size: 1.5rem !important;
+            h2 {
+                font-size: 1.75rem;
+            }
         }
     }
 
     @media (max-width: 480px) {
-        .statistics-component{
-            padding: 0 !important;
-        }
+        padding: 2.5rem 0.75rem;
 
-        .statistics-card {
-            flex: 1 1 100% !important;
-            max-width: 34vw !important;
-            min-width: 90px !important;
-            padding: 5px !important;
-        }
+        .statistics-section {
+            .statistics-container {
+                padding: 0 1rem;
+            }
 
-        h2{
-            font-size: 1rem !important;
+            .statistics-card {
+                max-width: 280px;
+                min-width: 180px;
+                padding: 20px 18px;
+            }
+
+            h2 {
+                font-size: 1.5rem;
+            }
         }
     }
 }

--- a/src/styles/blue.scss
+++ b/src/styles/blue.scss
@@ -10,7 +10,6 @@ body.blue-mode {
 
   .project-card,
   .skill-section,
-  .statistics-card,
   .popup {
     background-color: #ffffff;
     box-shadow: $section-box-shadow;
@@ -18,5 +17,16 @@ body.blue-mode {
 
   .point-on-line {
     background-color: #2563eb;
+  }
+
+  .statistics-component {
+    --stat-bg: linear-gradient(135deg, rgba(96, 165, 250, 0.22), rgba(59, 130, 246, 0.2), rgba(37, 99, 235, 0.22));
+    --stat-card-bg: rgba(255, 255, 255, 0.95);
+    --stat-card-border: rgba(59, 130, 246, 0.35);
+    --stat-icon-bg: rgba(37, 99, 235, 0.16);
+    --stat-icon-color: #1d4ed8;
+    --stat-label-color: #1f2937;
+    --stat-value-color: #102a43;
+    --stat-title-color: #0f172a;
   }
 }

--- a/src/styles/dark.scss
+++ b/src/styles/dark.scss
@@ -39,7 +39,6 @@ body.dark-mode {
 
     .project-card,
     .skill-section,
-    .statistics-card,
     .popup {
         background-color: #202127;
         box-shadow: $box-shadow-3d;
@@ -85,12 +84,15 @@ body.dark-mode {
         background-color: #6c63ff;
     }
 
-    .statistics-content {
-        .statistics-icon {
-            mat-icon {
-                color: #00bfa6;
-            }
-        }
+    .statistics-component {
+        --stat-bg: linear-gradient(135deg, rgba(42, 23, 96, 0.65), rgba(19, 34, 95, 0.6), rgba(16, 58, 69, 0.6));
+        --stat-card-bg: rgba(32, 33, 39, 0.92);
+        --stat-card-border: rgba(148, 163, 184, 0.18);
+        --stat-icon-bg: rgba(0, 191, 166, 0.22);
+        --stat-icon-color: #5eead4;
+        --stat-label-color: #cbd5f5;
+        --stat-value-color: #f8fafc;
+        --stat-title-color: #f9fafb;
     }
 
     .social-item a img {

--- a/src/styles/green.scss
+++ b/src/styles/green.scss
@@ -10,7 +10,6 @@ body.green-mode {
 
   .project-card,
   .skill-section,
-  .statistics-card,
   .popup {
     background-color: #ffffff;
     box-shadow: $section-box-shadow;
@@ -18,5 +17,16 @@ body.green-mode {
 
   .point-on-line {
     background-color: #10b981;
+  }
+
+  .statistics-component {
+    --stat-bg: linear-gradient(135deg, rgba(110, 231, 183, 0.22), rgba(52, 211, 153, 0.2), rgba(16, 185, 129, 0.22));
+    --stat-card-bg: rgba(255, 255, 255, 0.95);
+    --stat-card-border: rgba(52, 211, 153, 0.28);
+    --stat-icon-bg: rgba(16, 185, 129, 0.16);
+    --stat-icon-color: #047857;
+    --stat-label-color: #1f4033;
+    --stat-value-color: #14532d;
+    --stat-title-color: #064e3b;
   }
 }

--- a/src/styles/light.scss
+++ b/src/styles/light.scss
@@ -158,29 +158,14 @@ input[type='checkbox']:checked+.theme-switch-label {
 }
 
 .statistics-component {
-    .statistics-section {
-        .statistics-card {
-            border: 1px solid #e5e7eb;
-            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
-            border-radius: 14px;
-
-            .statistics-content {
-                .statistics-icon {
-                    mat-icon {
-                        color: #1f2937;
-                    }
-                }
-            }
-
-            .statistics-label {
-                color: #6b7280;
-            }
-        }
-
-        .statistics-section-title {
-            color: #1f2937;
-        }
-    }
+    --stat-bg: linear-gradient(135deg, rgba(108, 99, 255, 0.08), rgba(59, 130, 246, 0.08), rgba(0, 191, 166, 0.1));
+    --stat-card-bg: rgba(255, 255, 255, 0.94);
+    --stat-card-border: rgba(209, 213, 219, 0.5);
+    --stat-icon-bg: rgba(59, 130, 246, 0.14);
+    --stat-icon-color: #2563eb;
+    --stat-label-color: #4b5563;
+    --stat-value-color: #1f2937;
+    --stat-title-color: #1f2937;
 }
 
 .contact-me-section {


### PR DESCRIPTION
## Summary
- refresh the statistics section layout with gradient backgrounds and glassmorphism cards to echo the app palette
- drive the component styling through CSS custom properties and theme-specific overrides for light, dark, blue, and green modes

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e430fa5440832bb76b896e04ce35d0