### PR TITLE
Align sections to viewport height with centered content

### DIFF
--- a/src/app/components/hero/hero.component.scss
+++ b/src/app/components/hero/hero.component.scss
@@ -4,69 +4,72 @@
 }
 
 .bg-container {
+  position: relative;
   padding: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  height: 100vh;
+  min-height: 80vh;
+  height: 100%;
   text-align: center;
+}
 
-  
-  .bottom-border {
-    width: 100vw;
-    height: 7px;
-    position: absolute;
-    bottom: 0;
+.bottom-border {
+  width: 100vw;
+  height: 7px;
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.hero-content {
+  width: 50vw;
+  max-width: 600px;
+  z-index: 3;
+}
+
+.hero-content p {
+  margin: auto;
+}
+
+.hero-content button {
+  margin-top: 20px;
+  font-weight: bold;
+}
+
+@media (max-width: 768px) {
+  .bg-container {
+    padding: 0 1em;
+    min-height: 85vh;
+    height: auto;
+    padding-bottom: 10vh;
   }
 
   .hero-content {
-    width: 50vw;
-    z-index: 3;
-    max-width: 600px;
-
-    p {
-      margin: auto;
-    }
-
-    button {
-      margin-top: 20px;
-      font-weight: bold;
-    }
+    width: 80vw;
+    max-width: 90%;
+    padding: 0 10px;
   }
 
-  // Media Query per dispositivi mobili
-  @media (max-width: 768px) {
-    .bg-container {
-      padding: 0 1em; // Ridurre il padding sui dispositivi più piccoli
-      height: auto; // Permettere alla sezione di adattarsi automaticamente
-      padding-bottom: 10vh; // Aggiungere un po' di spazio sul fondo per il footer
-
-      .hero-content {
-        width: 80vw; // Rende il contenuto più largo sui dispositivi piccoli
-        max-width: 90%; // Imposta una larghezza massima per una visualizzazione ottimale
-        padding: 0 10px; // Aggiungi un po' di spazio interno
-
-        button {
-          font-size: 14px; // Ridurre la dimensione del testo per il bottone
-          padding: 10px 20px; // Diminuisci il padding per una maggiore compattezza
-        }
-      }
-    }
-
-    .bottom-border {
-      width: 100%; // Rendi la border della base più stretta sui dispositivi mobili
-    }
+  .hero-content button {
+    font-size: 14px;
+    padding: 10px 20px;
   }
 
-  // Media Query per schermi molto piccoli (es. telefoni più piccoli)
-  @media (max-width: 480px) {
-    .hero-content {
-      width: 90vw; // Rende il contenuto quasi a tutta larghezza
-      button {
-        font-size: 12px; // Ancora più piccolo sui dispositivi molto piccoli
-        padding: 8px 15px; // Riduci ancora il padding
-      }
-    }
+  .bottom-border {
+    width: 100%;
+  }
+}
+
+@media (max-width: 480px) {
+  .hero-content {
+    width: 90vw;
+  }
+
+  .hero-content button {
+    font-size: 12px;
+    padding: 8px 15px;
   }
 }

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -1,12 +1,44 @@
 <div *ngIf="viewInitialized">
-  <div #section><app-hero (navigateNextSection)="navigateNext()"></app-hero></div>
-  <div #section><app-about></app-about></div>
-  <div #section><app-projects></app-projects></div>
-  <div #section><app-skills></app-skills></div>
-  <div #section><app-education></app-education></div>
-  <div #section><app-experiences></app-experiences></div>
-  <div #section><app-stats></app-stats></div>
-  <div #section><app-contact-me></app-contact-me></div>
+  <section #section class="home__section">
+    <div class="home__section-content">
+      <app-hero (navigateNextSection)="navigateNext()"></app-hero>
+    </div>
+  </section>
+  <section #section class="home__section">
+    <div class="home__section-content">
+      <app-about></app-about>
+    </div>
+  </section>
+  <section #section class="home__section">
+    <div class="home__section-content">
+      <app-projects></app-projects>
+    </div>
+  </section>
+  <section #section class="home__section">
+    <div class="home__section-content">
+      <app-skills></app-skills>
+    </div>
+  </section>
+  <section #section class="home__section">
+    <div class="home__section-content">
+      <app-education></app-education>
+    </div>
+  </section>
+  <section #section class="home__section">
+    <div class="home__section-content">
+      <app-experiences></app-experiences>
+    </div>
+  </section>
+  <section #section class="home__section">
+    <div class="home__section-content">
+      <app-stats></app-stats>
+    </div>
+  </section>
+  <section #section class="home__section">
+    <div class="home__section-content">
+      <app-contact-me></app-contact-me>
+    </div>
+  </section>
 
   <div class="home__floating-controls" [class.home__floating-controls--assistant-open]="isAssistantOpen">
     <app-assistant (opened)="onAssistantOpened()" (closed)="onAssistantClosed()"></app-assistant>

--- a/src/app/pages/home/home.component.scss
+++ b/src/app/pages/home/home.component.scss
@@ -1,3 +1,30 @@
+.home__section {
+  position: relative;
+  width: 100%;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1.5rem, 4vh, 3rem) 0;
+}
+
+.home__section-content {
+  position: relative;
+  width: min(80vw, 1200px);
+  min-height: 80vh;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: stretch;
+  gap: clamp(1rem, 3vh, 2rem);
+}
+
+.home__section-content > * {
+  flex: 1 1 auto;
+  width: 100%;
+}
+
 .home__floating-controls {
   position: fixed;
   bottom: 30px;
@@ -21,6 +48,16 @@
 }
 
 @media (max-width: 768px) {
+  .home__section {
+    padding: clamp(1.25rem, 5vh, 2.5rem) 0;
+  }
+
+  .home__section-content {
+    width: min(90vw, 640px);
+    min-height: 85vh;
+    gap: clamp(0.75rem, 3vh, 1.5rem);
+  }
+
   .home__floating-controls {
     flex-direction: column;
     align-items: flex-end;


### PR DESCRIPTION
## Summary
- wrap each home section in a semantic container that can be sized independently from its content
- add layout styles that keep every section full-screen while constraining centered content to roughly 80% of the viewport with responsive tweaks
- adjust the hero component container to cooperate with the new sizing and retain mobile behavior

## Testing
- npm install *(fails: 403 Forbidden fetching @angular/compiler-cli)*

------
https://chatgpt.com/codex/tasks/task_e_68e4b6daedd0832ba88e7257b5d44543