### PR TITLE
Refine mobile projects carousel experience

### DIFF
--- a/src/app/components/projects/projects.carousel.component.scss
+++ b/src/app/components/projects/projects.carousel.component.scss
@@ -2,52 +2,61 @@
 .carousel-container {
     width: min(92vw, 420px);
     margin: 0 auto;
-    display: grid;
-    grid-template-columns: auto minmax(0, 1fr) auto;
-    align-items: center;
-    gap: 0.85rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.1rem;
+}
+
+.carousel-viewport {
+    overflow-x: auto;
+    overflow-y: visible;
+    scroll-snap-type: x mandatory;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+    mask-image: linear-gradient(90deg, transparent 0, rgba(0, 0, 0, 0.35) 16px, rgba(0, 0, 0, 1) 56px, rgba(0, 0, 0, 1) calc(100% - 56px), rgba(0, 0, 0, 0.35) calc(100% - 16px), transparent 100%);
+    padding-block: 0.25rem;
+
+    &::-webkit-scrollbar {
+        display: none;
+    }
 }
 
 .carousel-wrapper {
-    position: relative;
-    overflow: visible;
     display: flex;
-    width: 100%;
+    gap: 1.15rem;
+    padding-inline: 0.5rem 1.5rem;
+    transition: transform 0.6s ease;
 }
 
 .carousel-item {
-    width: 100%;
-    display: none;
-
-    &.active {
-        display: block;
-    }
+    flex: 0 0 calc(100% - 3.5rem);
+    scroll-snap-align: start;
+    scroll-snap-stop: always;
 }
 
-.arrow {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 2.5rem;
-    height: 2.5rem;
-    border-radius: 999px;
-    border: 1px solid rgba(56, 189, 248, 0.35);
-    background: rgba(255, 255, 255, 0.7);
-    box-shadow: 0 12px 28px rgba(15, 23, 42, 0.15);
-    backdrop-filter: blur(8px);
-    cursor: pointer;
-    font-size: 1.1rem;
-    color: #0f172a;
-    transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
+.carousel-container.is-peeking .carousel-wrapper {
+    animation: peek-next 4.2s ease-in-out 1;
+}
 
-    &:hover {
-        transform: translateY(-2px);
-        box-shadow: 0 16px 32px rgba(56, 189, 248, 0.2);
+@keyframes peek-next {
+    0% {
+        transform: translateX(0);
     }
 
-    &:focus-visible {
-        outline: 2px solid rgba(56, 189, 248, 0.8);
-        outline-offset: 3px;
+    20% {
+        transform: translateX(0);
+    }
+
+    55% {
+        transform: translateX(-14%);
+    }
+
+    75% {
+        transform: translateX(-14%);
+    }
+
+    100% {
+        transform: translateX(0);
     }
 }
 

--- a/src/app/components/projects/projects.component.html
+++ b/src/app/components/projects/projects.component.html
@@ -2,23 +2,17 @@
     <h2 class="projects-title">{{ projects.title }}</h2>
 
     <!-- Carosello per mobile -->
-    <div class="carousel-container" *ngIf="isMobile">
-        <button class="arrow arrow-left" type="button" (click)="moveToPrevious()"
-            [attr.aria-label]="projects.navigation.previous">
-            &#10094;
-        </button>
-
-        <div class="carousel-wrapper">
-            <div class="carousel-item" *ngFor="let project of projects.projects; let i = index"
-                [class.active]="i === currentIndex">
-                <ng-container *ngTemplateOutlet="projectCard; context: { $implicit: project, index: i }"></ng-container>
+    <div class="carousel-container" *ngIf="isMobile" [class.is-peeking]="shouldPeek">
+        <div class="carousel-viewport" role="listbox" tabindex="0" [attr.aria-label]="projects.title"
+            (scroll)="handleCarouselInteraction()" (touchstart)="handleCarouselInteraction()"
+            (mousedown)="handleCarouselInteraction()">
+            <div class="carousel-wrapper">
+                <div class="carousel-item" *ngFor="let project of projects.projects; let i = index" role="option"
+                    [attr.aria-label]="project.title">
+                    <ng-container *ngTemplateOutlet="projectCard; context: { $implicit: project, index: i }"></ng-container>
+                </div>
             </div>
         </div>
-
-        <button class="arrow arrow-right" type="button" (click)="moveToNext()"
-            [attr.aria-label]="projects.navigation.next">
-            &#10095;
-        </button>
     </div>
 
     <!-- Griglia per desktop -->

--- a/src/app/components/projects/projects.component.spec.ts
+++ b/src/app/components/projects/projects.component.spec.ts
@@ -82,43 +82,29 @@ describe('ProjectsComponent', () => {
    */
   it('should update isMobile flag on window resize', () => {
     globalThis.innerWidth = 500;
-    component.onResize(new Event('resize'));
+    component.onResize();
     expect(component.isMobile).toBeTrue();
 
     globalThis.innerWidth = 1000;
-    component.onResize(new Event('resize'));
+    component.onResize();
     expect(component.isMobile).toBeFalse();
   });
 
   /**
-   * Verifies that moveToNext correctly navigates to the next project.
+   * Ensures user interactions stop the automatic peek animation.
    */
-  it('should move to next project', async () => {
-    await fixture.whenStable();
-    fixture.detectChanges();
+  it('should stop peek animation on interaction', () => {
+    // Arrange timers so that the component has pending animation steps.
+    component['peekStartTimeoutId'] = setTimeout(() => fail('start timeout should be cleared'), 1000);
+    component['peekStopTimeoutId'] = setTimeout(() => fail('stop timeout should be cleared'), 1000);
+    component.shouldPeek = true;
 
-    component.currentIndex = 0;
-    component.moveToNext();
-    expect(component.currentIndex).toBe(1);
+    // Act - simulate user interaction with the carousel viewport.
+    component.handleCarouselInteraction();
 
-    component.currentIndex = component.projects.projects.length - 1;
-    component.moveToNext();
-    expect(component.currentIndex).toBe(0);
-  });
-
-  /**
-   * Verifies that moveToPrevious correctly navigates to the previous project.
-   */
-  it('should move to previous project', async () => {
-    await fixture.whenStable();
-    fixture.detectChanges();
-
-    component.currentIndex = 1;
-    component.moveToPrevious();
-    expect(component.currentIndex).toBe(0);
-
-    component.currentIndex = 0;
-    component.moveToPrevious();
-    expect(component.currentIndex).toBe(component.projects.projects.length - 1);
+    // Assert - timers are cleared and peek animation is disabled.
+    expect(component['peekStartTimeoutId']).toBeNull();
+    expect(component['peekStopTimeoutId']).toBeNull();
+    expect(component.shouldPeek).toBeFalse();
   });
 });


### PR DESCRIPTION
## Summary
- replace the mobile projects carousel navigation arrows with a scrollable viewport that reveals the upcoming card and auto-peeks on load
- add TypeScript logic to trigger and cancel the peek animation based on viewport changes and user interaction, cleaning up timers on destroy
- update the unit tests to cover the new interaction handling logic

## Testing
- npm test -- --watch=false --browsers=ChromeHeadless *(fails: ng CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4b79d93b0832b82bd29169cb72cba