### PR TITLE
Fix assistant layout width on mobile

### DIFF
--- a/src/app/components/assistant/assistant.component.scss
+++ b/src/app/components/assistant/assistant.component.scss
@@ -2,7 +2,7 @@
   --assistant-avatar-size: var(--assistant-avatar-size-sm, 48px);
   --assistant-spacing: clamp(12px, 2vw, 18px);
   --assistant-popup-width: clamp(360px, 72vw, 540px);
-  display: block;
+  display: inline-flex;
   position: relative;
   max-width: 100%;
 }


### PR DESCRIPTION
## Summary
- change the assistant host element to use inline-flex so it keeps its intended footprint on smaller screens

## Testing
- npm install *(fails: 403 Forbidden fetching @angular/compiler-cli)*

------
https://chatgpt.com/codex/tasks/task_e_68e504a2807c832b91180ae807432a74