### PR TITLE
Refine featured projects cards and scrolling

### DIFF
--- a/src/app/components/projects/projects.component.html
+++ b/src/app/components/projects/projects.component.html
@@ -23,7 +23,7 @@
     </div>
 
     <ng-template #projectCard let-project let-i="index">
-        <article class="project-card" [class.expanded]="project.expanded" [attr.data-status-level]="project.status.level">
+        <article class="project-card" [attr.data-status-level]="project.status.level">
             <div class="project-visual">
                 <img class="proj-image" [src]="project.image" [attr.alt]="'Anteprima del progetto ' + project.title" />
             </div>
@@ -45,18 +45,13 @@
 
             <p class="project-technologies">{{ project.technologies.join(' · ') }}</p>
 
-            <div class="project-description" [class.expanded]="project.expanded">
-                <div class="description-content" [attr.id]="'project-description-' + i">
+            <div class="project-description" [class.is-scrollable]="project.isScrollable"
+                [class.is-at-end]="project.isAtEnd">
+                <div class="description-content" #descriptionContent [attr.id]="'project-description-' + i" tabindex="0"
+                    role="region" [attr.aria-label]="project.title + ' — dettagli'"
+                    (scroll)="onDescriptionScroll(project, $event)">
                     <p>{{ project.description }}</p>
                 </div>
-                <button type="button" class="description-toggle" (click)="toggleExpand(project)"
-                    [attr.aria-expanded]="project.expanded" [attr.aria-controls]="'project-description-' + i"
-                    [attr.aria-label]="(project.expanded ? projects.toggle.collapse : projects.toggle.expand).trim()">
-                    <span class="toggle-label">
-                        {{ (project.expanded ? projects.toggle.collapse : projects.toggle.expand).trim() }}
-                    </span>
-                    <span class="toggle-icon" aria-hidden="true"></span>
-                </button>
             </div>
 
             <a class="proj-link" [href]="project.link" target="_blank">{{ projects.button }}</a>

--- a/src/app/components/projects/projects.component.scss
+++ b/src/app/components/projects/projects.component.scss
@@ -39,8 +39,8 @@
     position: relative;
     display: flex;
     flex-direction: column;
-    gap: clamp(1rem, 2.2vw, 1.35rem);
-    padding: clamp(1.5rem, 3vw, 2rem);
+    gap: clamp(0.85rem, 2vw, 1.15rem);
+    padding: clamp(1.35rem, 2.8vw, 1.75rem);
     border-radius: 22px;
     background: linear-gradient(135deg, rgba(255, 255, 255, 0.9), rgba(224, 242, 254, 0.65));
     border: 1px solid var(--projects-card-border);
@@ -59,7 +59,7 @@
     border-radius: 18px;
     background: rgba(255, 255, 255, 0.65);
     border: 1px solid rgba(56, 189, 248, 0.18);
-    padding: 0.85rem;
+    padding: 0.75rem;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -67,7 +67,7 @@
 
 .proj-image {
     width: 100%;
-    height: clamp(140px, 32vw, 170px);
+    height: clamp(120px, 28vw, 160px);
     object-fit: contain;
     object-position: center;
     filter: drop-shadow(0 12px 24px rgba(15, 23, 42, 0.18));
@@ -76,7 +76,7 @@
 .project-header {
     display: flex;
     flex-direction: column;
-    gap: 0.9rem;
+    gap: 0.65rem;
 }
 
 .project-title {
@@ -87,9 +87,9 @@
 
 .project-status-wrapper {
     display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 0.75rem;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.55rem;
 }
 
 .project-status-pill {
@@ -125,7 +125,7 @@
 .project-status-tags {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.45rem;
+    gap: 0.4rem;
     padding: 0;
     margin: 0;
     list-style: none;
@@ -145,7 +145,7 @@
 
 .project-technologies {
     margin: 0;
-    font-size: 0.95rem;
+    font-size: 0.92rem;
     color: var(--projects-text-muted);
 }
 
@@ -153,8 +153,7 @@
     position: relative;
     display: flex;
     flex-direction: column;
-    gap: 0.85rem;
-    padding: 1.1rem 1.15rem 1.35rem;
+    padding: 1.05rem 1.15rem 1.1rem;
     border-radius: 18px;
     background: linear-gradient(135deg, rgba(255, 255, 255, 0.82), rgba(224, 242, 254, 0.55));
     border: 1px solid rgba(56, 189, 248, 0.25);
@@ -168,83 +167,40 @@
     position: absolute;
     left: 0;
     right: 0;
-    bottom: 3.2rem;
-    height: 3rem;
+    bottom: 0;
+    height: 2.85rem;
     pointer-events: none;
-    background: linear-gradient(180deg, rgba(255, 255, 255, 0), rgba(224, 242, 254, 0.95));
+    background: linear-gradient(180deg, rgba(224, 242, 254, 0), rgba(224, 242, 254, 0.92));
+    filter: blur(0.5px);
+    opacity: 0;
     transition: opacity 0.35s ease;
 }
 
-.project-description.expanded::after {
+.project-description.is-scrollable::after {
+    opacity: 0.9;
+}
+
+.project-description.is-scrollable.is-at-end::after {
     opacity: 0;
 }
 
 .description-content {
-    max-height: 7.5rem;
-    overflow: hidden;
-    transition: max-height 0.5s ease;
+    max-height: 8.5rem;
+    overflow-y: auto;
+    padding-right: 0.35rem;
+    margin-right: -0.35rem;
+    scrollbar-width: none;
+    -ms-overflow-style: none;
 
     p {
         margin: 0;
-        line-height: 1.6;
-        color: rgba(15, 23, 42, 0.82);
+        line-height: 1.55;
+        color: rgba(15, 23, 42, 0.85);
     }
 }
 
-.project-description.expanded .description-content {
-    max-height: 900px;
-}
-
-.description-toggle {
-    align-self: center;
-    display: inline-flex;
-    align-items: center;
-    gap: 0.55rem;
-    padding: 0.45rem 0.95rem;
-    border-radius: 999px;
-    border: 1px solid rgba(56, 189, 248, 0.35);
-    background: rgba(255, 255, 255, 0.7);
-    color: #0f172a;
-    font-weight: 600;
-    font-size: 0.9rem;
-    letter-spacing: 0.01em;
-    cursor: pointer;
-    transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
-    backdrop-filter: blur(8px);
-
-    &:hover {
-        transform: translateY(-2px);
-        box-shadow: 0 16px 32px rgba(56, 189, 248, 0.2);
-    }
-
-    &:focus-visible {
-        outline: 2px solid rgba(56, 189, 248, 0.8);
-        outline-offset: 3px;
-    }
-}
-
-.toggle-icon {
-    position: relative;
-    width: 0.9rem;
-    height: 0.9rem;
-}
-
-.toggle-icon::before,
-.toggle-icon::after {
-    content: "";
-    position: absolute;
-    background: currentColor;
-    border-radius: 999px;
-    inset: calc(50% - 1px) 0;
-}
-
-.toggle-icon::after {
-    transform: rotate(90deg);
-    transition: transform 0.3s ease;
-}
-
-.project-description.expanded .toggle-icon::after {
-    transform: rotate(90deg) scaleX(0);
+.description-content::-webkit-scrollbar {
+    display: none;
 }
 
 .proj-link {

--- a/src/app/components/projects/projects.component.spec.ts
+++ b/src/app/components/projects/projects.component.spec.ts
@@ -36,30 +36,24 @@ describe('ProjectsComponent', () => {
   });
 
   /**
-   * Ensures translated project data is rendered and the toggle button updates expansion state.
+   * Ensures the project description is rendered without the legacy toggle button.
    */
-  it('should toggle project expansion via the template control', async () => {
+  it('should render the project description without a toggle button', async () => {
     await fixture.whenStable();
     fixture.detectChanges();
 
-    const firstProject = component.projects.projects[0];
     const toggleButton: HTMLButtonElement | null = fixture.nativeElement.querySelector('.description-toggle');
-    expect(toggleButton).withContext('toggle button should exist').not.toBeNull();
+    const descriptionRegion: HTMLElement | null = fixture.nativeElement.querySelector('.description-content');
 
-    expect(firstProject.expanded).toBeFalse();
-    expect(toggleButton?.getAttribute('aria-expanded')).toBe('false');
-
-    toggleButton?.click();
-    fixture.detectChanges();
-
-    expect(firstProject.expanded).toBeTrue();
-    expect(toggleButton?.getAttribute('aria-expanded')).toBe('true');
+    expect(toggleButton).withContext('toggle button should not be present').toBeNull();
+    expect(descriptionRegion).withContext('description content should be rendered').not.toBeNull();
+    expect(descriptionRegion?.getAttribute('tabindex')).toBe('0');
   });
 
   /**
-   * Verifies that toggleExpand correctly toggles the expanded state of a project instance.
+   * Verifies that the scroll handler updates the scroll boundary state.
    */
-  it('should toggle expand state correctly', () => {
+  it('should update scroll state when the description is scrolled', () => {
     const project: Project = {
       title: 'Sample project',
       description: 'Description',
@@ -67,14 +61,29 @@ describe('ProjectsComponent', () => {
       status: { level: 'active' },
       image: 'image.png',
       link: 'https://example.com',
-      expanded: false
+      isScrollable: true,
+      isAtEnd: false
     };
 
-    component.toggleExpand(project);
-    expect(project.expanded).toBeTrue();
+    component.onDescriptionScroll(project, {
+      target: {
+        scrollTop: 0,
+        clientHeight: 100,
+        scrollHeight: 200
+      }
+    } as unknown as Event);
 
-    component.toggleExpand(project);
-    expect(project.expanded).toBeFalse();
+    expect(project.isAtEnd).toBeFalse();
+
+    component.onDescriptionScroll(project, {
+      target: {
+        scrollTop: 110,
+        clientHeight: 100,
+        scrollHeight: 200
+      }
+    } as unknown as Event);
+
+    expect(project.isAtEnd).toBeTrue();
   });
 
   /**

--- a/src/app/data/projects.data.ts
+++ b/src/app/data/projects.data.ts
@@ -34,8 +34,7 @@ export const projects: ProjectsLangs = {
                 technologies: ['Angular 16', 'TypeScript', 'RxJS', 'SCSS', 'Node.js'],
                 description: 'Suite modulare di mini-giochi casual con core condiviso, profili giocatore e leaderboard mobile-ready per sessioni rapide.',
                 image: 'https://github.com/DiegoFCJ/MicroGames/blob/master/overview/loggedPage.png?raw=true',
-                link: 'https://github.com/DiegoFCJ/MicroGames',
-                expanded: false
+                link: 'https://github.com/DiegoFCJ/MicroGames'
             },
             {
                 title: 'Self',
@@ -46,8 +45,7 @@ export const projects: ProjectsLangs = {
                 technologies: ['Angular 17', 'NestJS', 'PostgreSQL', 'Docker', 'Redis'],
                 description: 'Hub di produttività che traccia abitudini, espone un marketplace di plugin e sincronizza obiettivi con promemoria su calendario multi-dispositivo.',
                 image: 'https://github.com/DiegoFCJ/self/blob/master/self.png?raw=true',
-                link: 'https://github.com/DiegoFCJ/self',
-                expanded: false
+                link: 'https://github.com/DiegoFCJ/self'
             },
             {
                 title: 'E-commerce',
@@ -57,8 +55,7 @@ export const projects: ProjectsLangs = {
                 technologies: ['Spring Boot 3', 'Angular 17', 'MySQL', 'Keycloak', 'Docker'],
                 description: 'Template headless per e-commerce con checkout modulare, workflow di magazzino e dashboard amministrativa pronta per integrazioni ERP.',
                 image: 'https://github.com/DiegoFCJ/E-commerce/blob/master/overview/homeSideDash.png?raw=true',
-                link: 'https://github.com/DiegoFCJ/E-commerce',
-                expanded: false
+                link: 'https://github.com/DiegoFCJ/E-commerce'
             }
         ]
     },
@@ -95,8 +92,7 @@ export const projects: ProjectsLangs = {
                 technologies: ['Angular 16', 'TypeScript', 'RxJS', 'SCSS', 'Node.js'],
                 description: 'Modular suite of casual mini-games with shared core, player profiles and a mobile-ready leaderboard for quick sessions.',
                 image: 'https://github.com/DiegoFCJ/MicroGames/blob/master/overview/loggedPage.png?raw=true',
-                link: 'https://github.com/DiegoFCJ/MicroGames',
-                expanded: false
+                link: 'https://github.com/DiegoFCJ/MicroGames'
             },
             {
                 title: 'Self',
@@ -107,8 +103,7 @@ export const projects: ProjectsLangs = {
                 technologies: ['Angular 17', 'NestJS', 'PostgreSQL', 'Docker', 'Redis'],
                 description: 'Productivity hub that tracks habits, exposes a plugin marketplace and syncs goals with calendar reminders across devices.',
                 image: 'https://github.com/DiegoFCJ/self/blob/master/self.png?raw=true',
-                link: 'https://github.com/DiegoFCJ/self',
-                expanded: false
+                link: 'https://github.com/DiegoFCJ/self'
             },
             {
                 title: 'E-commerce',
@@ -118,8 +113,7 @@ export const projects: ProjectsLangs = {
                 technologies: ['Spring Boot 3', 'Angular 17', 'MySQL', 'Keycloak', 'Docker'],
                 description: 'Headless commerce template with modular checkout, inventory workflows and an admin dashboard ready for ERP integrations.',
                 image: 'https://github.com/DiegoFCJ/E-commerce/blob/master/overview/homeSideDash.png?raw=true',
-                link: 'https://github.com/DiegoFCJ/E-commerce',
-                expanded: false
+                link: 'https://github.com/DiegoFCJ/E-commerce'
             }
         ]
     }

--- a/src/app/dtos/ProjectDTO.ts
+++ b/src/app/dtos/ProjectDTO.ts
@@ -28,7 +28,8 @@ export interface Project {
     status: ProjectStatus;
     image: string;
     link: string;
-    expanded?: boolean;
+    isScrollable?: boolean;
+    isAtEnd?: boolean;
 }
 
 export type ProjectStatusLevel = 'active' | 'publicBeta' | 'inDevelopment';


### PR DESCRIPTION
## Summary
- tighten the featured projects card layout and remove the old expand/collapse control
- make project descriptions scrollable within the card with a hidden scrollbar and gradient cue when content overflows
- drop the obsolete expanded flag from data/DTOs and adjust component logic and specs for the new scroll behavior

## Testing
- Not run (npm install failed: registry returned 403)


------
https://chatgpt.com/codex/tasks/task_e_68e5056334a4832b84c19c74311f8b49