### PR TITLE
Revamp skills section layout and icon interaction

### DIFF
--- a/src/app/components/skills/skills.component.html
+++ b/src/app/components/skills/skills.component.html
@@ -34,7 +34,7 @@
       <button class="arrow-left" type="button" (click)="moveToPrevious()" aria-label="Previous stack section">&#10094;</button>
       <div class="carousel-wrapper" [style.transform]="'translateX(-' + currentIndex * 100 + '%)'">
         <article
-          *ngFor="let panel of activePanels; let i = index; let last = last"
+          *ngFor="let panel of activePanels; let i = index"
           class="carousel-item"
           [class.active]="i === currentIndex"
           role="group"
@@ -42,17 +42,8 @@
           [attr.aria-label]="panel.title"
         >
           <div class="spotlight-card is-mobile" data-skill-host>
-            <div class="spotlight-rail is-mobile" [class.is-last]="last">
-              <span class="spotlight-dot" aria-hidden="true"></span>
-              <span class="spotlight-line" aria-hidden="true" [class.is-last]="last"></span>
-            </div>
             <div class="spotlight-content">
-              <header class="spotlight-header">
-                <div class="header-text">
-                  <h3 class="spotlight-title">{{ panel.title }}</h3>
-                  <p class="spotlight-subtitle" *ngIf="panel.subtitle">{{ panel.subtitle }}</p>
-                </div>
-              </header>
+              <p class="spotlight-subtitle" *ngIf="panel.subtitle">{{ panel.subtitle }}</p>
               <div class="spotlight-icons" role="list">
                 <div
                   *ngFor="let skill of panel.skills"
@@ -60,6 +51,8 @@
                   role="listitem"
                   data-skill-host
                   [attr.aria-label]="skill.name"
+                  [class.clicked]="skill.clicked"
+                  (click)="onSkillClick(skill)"
                 >
                   <span class="icon-asset">
                     <img [src]="skill.icon" [alt]="skill.name" />
@@ -103,22 +96,9 @@
         [attr.aria-labelledby]="'tab-' + activeTabId"
         [attr.id]="'panel-' + activeTabId"
       >
-        <article
-          class="spotlight-card"
-          *ngFor="let panel of activePanels; let last = last"
-          data-skill-host
-        >
-          <div class="spotlight-rail" [class.is-last]="last">
-            <span class="spotlight-dot" aria-hidden="true"></span>
-            <span class="spotlight-line" aria-hidden="true" [class.is-last]="last"></span>
-          </div>
+        <article class="spotlight-card" *ngFor="let panel of activePanels" data-skill-host>
           <div class="spotlight-content">
-            <header class="spotlight-header">
-              <div class="header-text">
-                <h3 class="spotlight-title">{{ panel.title }}</h3>
-                <p class="spotlight-subtitle" *ngIf="panel.subtitle">{{ panel.subtitle }}</p>
-              </div>
-            </header>
+            <p class="spotlight-subtitle" *ngIf="panel.subtitle">{{ panel.subtitle }}</p>
             <div class="spotlight-icons" role="list">
               <div
                 *ngFor="let skill of panel.skills"
@@ -126,6 +106,8 @@
                 role="listitem"
                 data-skill-host
                 [attr.aria-label]="skill.name"
+                [class.clicked]="skill.clicked"
+                (click)="onSkillClick(skill)"
               >
                 <span class="icon-asset">
                   <img [src]="skill.icon" [alt]="skill.name" />

--- a/src/app/components/skills/skills.component.scss
+++ b/src/app/components/skills/skills.component.scss
@@ -119,10 +119,10 @@
 
 .spotlight-card {
   position: relative;
-  display: grid;
-  grid-template-columns: clamp(2.5rem, 4vw, 3rem) 1fr;
-  gap: clamp(1rem, 2.5vw, 1.75rem);
-  padding: clamp(1.5rem, 3vw, 2.4rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.25rem, 2.5vw, 1.9rem);
+  padding: clamp(1.75rem, 3.5vw, 2.75rem);
   background: linear-gradient(135deg, var(--skills-card-bg), rgba(99, 102, 241, 0.12));
   border: 1px solid var(--skills-card-border);
   border-radius: 24px;
@@ -141,54 +141,8 @@
 }
 
 .spotlight-card.is-mobile {
-  grid-template-columns: 1fr;
-  gap: 1.25rem;
-  padding: clamp(1.75rem, 6vw, 2.5rem);
+  padding: clamp(1.5rem, 5.5vw, 2.5rem);
   border-radius: 22px;
-}
-
-.spotlight-rail {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.spotlight-rail.is-mobile {
-  flex-direction: column;
-  align-items: center;
-  order: -1;
-  gap: 0.75rem;
-}
-
-.spotlight-dot {
-  width: 18px;
-  height: 18px;
-  border-radius: 999px;
-  background: var(--skills-accent);
-  box-shadow: 0 0 0 6px var(--skills-accent-soft), 0 15px 35px rgba(79, 70, 229, 0.18);
-}
-
-.spotlight-line {
-  flex: 1;
-  width: 3px;
-  background: linear-gradient(180deg, var(--skills-accent), rgba(99, 102, 241, 0));
-  border-radius: 999px;
-}
-
-.spotlight-line.is-last {
-  display: none;
-}
-
-.spotlight-card.is-mobile .spotlight-line {
-  width: 64px;
-  height: 3px;
-  flex: 0 0 auto;
-  background: linear-gradient(90deg, var(--skills-accent), rgba(99, 102, 241, 0));
-}
-
-.spotlight-card.is-mobile .spotlight-line.is-last {
-  display: none;
 }
 
 .spotlight-content {
@@ -197,54 +151,53 @@
   gap: clamp(1rem, 2vw, 1.5rem);
 }
 
-.spotlight-header {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: flex-start;
-  align-items: flex-start;
-  gap: 0.75rem;
-}
-
-.header-text {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-}
-
-.spotlight-title {
+.spotlight-subtitle {
   margin: 0;
-  font-size: clamp(1.25rem, 2.5vw, 1.6rem);
+  font-size: clamp(1rem, 2.2vw, 1.25rem);
   font-weight: 700;
+  letter-spacing: 0.01em;
+  text-transform: none;
   color: #0f172a;
 }
 
-:host-context(body.dark-mode) .spotlight-title {
+:host-context(body.dark-mode) .spotlight-subtitle {
   color: #f8fafc;
-}
-
-.spotlight-subtitle {
-  margin: 0;
-  font-size: 0.9rem;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: var(--skills-text-muted);
 }
 
 .spotlight-icons {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: clamp(0.75rem, 2vw, 1.25rem);
+  grid-template-columns: repeat(auto-fit, minmax(82px, 1fr));
+  gap: clamp(1rem, 2.5vw, 1.75rem);
 }
 
 .skill-icon {
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: clamp(0.75rem, 2vw, 1.25rem);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.75);
+  border: 1px solid rgba(99, 102, 241, 0.2);
+  box-shadow: 0 10px 22px rgba(15, 23, 42, 0.08);
+  cursor: pointer;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+:host-context(body.dark-mode) .skill-icon {
+  background: rgba(30, 31, 38, 0.85);
+  border-color: rgba(129, 140, 248, 0.35);
+  box-shadow: 0 10px 26px rgba(15, 23, 42, 0.45);
+}
+
+.skill-icon:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.12);
 }
 
 .icon-asset {
-  width: 100%;
+  width: clamp(3.25rem, 6vw, 4.25rem);
+  height: clamp(3.25rem, 6vw, 4.25rem);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -252,8 +205,22 @@
 
 .icon-asset img {
   width: 100%;
-  max-height: 42px;
+  max-height: clamp(3rem, 5.5vw, 3.75rem);
   object-fit: contain;
+}
+
+.skill-icon.clicked .icon-asset img {
+  animation: skill-spin 0.7s ease;
+}
+
+@keyframes skill-spin {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 @media (max-width: 1200px) {
@@ -276,7 +243,7 @@
 
 @media (max-width: 768px) {
   .spotlight-icons {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(72px, 1fr));
   }
 }
 
@@ -286,7 +253,7 @@
   }
 
   .spotlight-icons {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(64px, 1fr));
   }
 }
 

--- a/src/app/components/skills/skills.component.ts
+++ b/src/app/components/skills/skills.component.ts
@@ -49,6 +49,7 @@ export class SkillsComponent implements OnInit, OnDestroy {
     frontend: ['front-end', 'frontend', 'ui', 'linguaggi', 'programming', 'languages'],
     tooling: ['testing', 'documentazione', 'documentation', 'build', 'version', 'collaboration', 'collaborazione', 'management', 'operating', 'sistemi', 'tooling']
   };
+  private readonly skillResetTimers = new WeakMap<SkillItem, number>();
 
   private readonly tabLabelDictionary: Record<SkillTabId, Record<LanguageCode | 'default', string>> = {
     backend: {
@@ -162,6 +163,31 @@ export class SkillsComponent implements OnInit, OnDestroy {
       return;
     }
     this.currentIndex = (this.currentIndex - 1 + items.length) % items.length;
+  }
+
+  onSkillClick(skill: SkillItem): void {
+    if (!this.isBrowser) {
+      return;
+    }
+
+    const timer = this.skillResetTimers.get(skill);
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      this.skillResetTimers.delete(skill);
+    }
+
+    skill.clicked = false;
+
+    window.requestAnimationFrame(() => {
+      skill.clicked = true;
+
+      const resetTimer = window.setTimeout(() => {
+        skill.clicked = false;
+        this.skillResetTimers.delete(skill);
+      }, 750);
+
+      this.skillResetTimers.set(skill, resetTimer);
+    });
   }
 
   private resetCarouselIndex(): void {


### PR DESCRIPTION
## Summary
- remove the timeline rail and titles from each skills card to focus on subtitles and technologies
- enlarge and restyle skill icon tiles so the technologies are clearer at a glance
- restore the 360° spin easter egg when a skill icon is clicked

## Testing
- `npm install` *(fails: registry returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e50607cdb4832b847b28c034d2a37b