### PR TITLE
Ensure navigator tooltips overlay assistant UI

### DIFF
--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -97,3 +97,8 @@ mat-error {
         bottom: 60px !important;
     }
 }
+
+// Ensure Material tooltips appear above every other UI element, including the assistant overlay
+.mat-mdc-tooltip-panel {
+    z-index: 2147483647 !important;
+}


### PR DESCRIPTION
## Summary
- raise the Angular Material tooltip panel z-index so navbar hints appear above the assistant overlay

## Testing
- npm install *(fails: 403 Forbidden - GET https://registry.npmjs.org/@angular%2fcompiler-cli)*

------
https://chatgpt.com/codex/tasks/task_e_68e50a10ed44832b8b94410c603083cc