### PR TITLE
Fix mobile overflow in About section

### DIFF
--- a/src/app/components/about/about.component.scss
+++ b/src/app/components/about/about.component.scss
@@ -42,6 +42,7 @@
     border: 1px solid var(--about-card-border);
     border-radius: 24px;
     padding: clamp(2rem, 5vw, 3rem);
+    box-sizing: border-box;
     box-shadow: 0 24px 55px rgba(15, 23, 42, 0.12);
     backdrop-filter: blur(10px);
     display: flex;


### PR DESCRIPTION
## Summary
- ensure the About section container uses border-box sizing so its padding no longer forces horizontal overflow on narrow screens

## Testing
- npm install *(fails: 403 Forbidden when downloading @angular/compiler-cli)*

------
https://chatgpt.com/codex/tasks/task_e_68e50a3c26b0832bb47487fbd34fbd0a