### PR TITLE
Adjust timeline widths for education and experience sections

### DIFF
--- a/src/app/components/education/education.component.scss
+++ b/src/app/components/education/education.component.scss
@@ -50,7 +50,7 @@
 
 .timeline {
   --timeline-gap: clamp(1.75rem, 3vw, 2.75rem);
-  width: 100%;
+  width: min(80%, 1024px);
   display: grid;
   gap: var(--timeline-gap);
   margin: 0 auto;
@@ -155,7 +155,7 @@
 @media (max-width: 768px) {
   .timeline {
     --timeline-gap: clamp(1.5rem, 4vw, 2rem);
-    width: 100%;
+    width: 90%;
   }
 
   .education-content {
@@ -178,6 +178,10 @@
 
   .education-content {
     width: 100%;
+  }
+
+  .timeline {
+    width: 90%;
   }
 
   .timeline-item {

--- a/src/app/components/experiences/experiences.component.scss
+++ b/src/app/components/experiences/experiences.component.scss
@@ -63,8 +63,7 @@
 
 .timeline {
   --timeline-gap: clamp(1.75rem, 3vw, 2.75rem);
-  width: 100%;
-  max-width: 1024px;
+  width: min(80%, 1024px);
   display: grid;
   gap: var(--timeline-gap);
   margin: 0 auto;
@@ -212,7 +211,7 @@
 @media (max-width: 768px) {
   .timeline {
     --timeline-gap: clamp(1.5rem, 4vw, 2rem);
-    width: 100%;
+    width: 90%;
   }
 
   .timeline-item {
@@ -228,6 +227,7 @@
 
   .timeline {
     --timeline-gap: clamp(1.35rem, 4vw, 1.85rem);
+    width: 90%;
   }
 
   .timeline-item {


### PR DESCRIPTION
## Summary
- constrain the education timeline container to 80% width on desktop and 90% on small screens
- apply the same responsive width treatment to the experiences timeline for consistency

## Testing
- npm install *(fails: 403 Forbidden fetching @angular/compiler-cli)*

------
https://chatgpt.com/codex/tasks/task_e_68e50afc60d4832b809bd891aecc3e59