### PR TITLE
Align experience section timeline with education UI

### DIFF
--- a/src/app/components/experiences/experiences.component.html
+++ b/src/app/components/experiences/experiences.component.html
@@ -1,31 +1,33 @@
 <section class="experiences-section" *ngIf="!isLoading">
-  <h2 class="experiences-title">{{ experiences.title }}</h2>
-  <div class="timeline" role="list">
-    <article
-      class="timeline-item"
-      role="listitem"
-      *ngFor="let experience of experiences.experiences; let last = last"
-    >
-      <div class="timeline-marker" [class.is-last]="last">
-        <span class="timeline-dot" aria-hidden="true"></span>
-      </div>
-      <div class="timeline-card">
-        <header class="timeline-header">
-          <h3 class="timeline-heading">{{ experience.position }}</h3>
-          <span class="timeline-badge">{{ experience.formattedPeriod }}</span>
-        </header>
-        <p class="timeline-company" *ngIf="experience.company">{{ experience.company }}</p>
-        <p class="timeline-location">{{ experience.location }}</p>
-        <p class="timeline-technologies" *ngIf="experience.technologies">
-          {{ experience.technologies }}
-        </p>
-        <p class="timeline-summary" *ngIf="experience.responsibilities">
-          {{ experience.responsibilities }}
-        </p>
-        <ul class="timeline-responsibilities" *ngIf="experience.responsibilityItems?.length">
-          <li *ngFor="let item of experience.responsibilityItems">{{ item }}</li>
-        </ul>
-      </div>
-    </article>
+  <div class="experiences-content">
+    <h2 class="experiences-title">{{ experiences.title }}</h2>
+    <div class="timeline" role="list">
+      <article
+        class="timeline-item"
+        role="listitem"
+        *ngFor="let experience of experiences.experiences; let last = last"
+      >
+        <div class="timeline-marker" [class.is-last]="last">
+          <span class="timeline-dot" aria-hidden="true"></span>
+        </div>
+        <div class="timeline-card">
+          <header class="timeline-header">
+            <h3 class="timeline-heading">{{ experience.position }}</h3>
+            <span class="timeline-badge">{{ experience.formattedPeriod }}</span>
+          </header>
+          <p class="timeline-company" *ngIf="experience.company">{{ experience.company }}</p>
+          <p class="timeline-location">{{ experience.location }}</p>
+          <p class="timeline-technologies" *ngIf="experience.technologies">
+            {{ experience.technologies }}
+          </p>
+          <p class="timeline-summary" *ngIf="experience.responsibilities">
+            {{ experience.responsibilities }}
+          </p>
+          <ul class="timeline-responsibilities" *ngIf="experience.responsibilityItems?.length">
+            <li *ngFor="let item of experience.responsibilityItems">{{ item }}</li>
+          </ul>
+        </div>
+      </article>
+    </div>
   </div>
 </section>

--- a/src/app/components/experiences/experiences.component.scss
+++ b/src/app/components/experiences/experiences.component.scss
@@ -1,42 +1,27 @@
 :host {
-  --experience-accent: #6366f1;
-  --experience-accent-soft: rgba(99, 102, 241, 0.18);
-  --experience-card-bg: rgba(15, 23, 42, 0.05);
-  --experience-card-highlight: rgba(99, 102, 241, 0.12);
-  --experience-card-border: rgba(99, 102, 241, 0.25);
-  --experience-card-shadow: 0 22px 55px rgba(79, 70, 229, 0.12);
-  --experience-text-muted: rgba(15, 23, 42, 0.65);
-  --experience-heading-color: #0f172a;
-  --experience-summary-color: rgba(15, 23, 42, 0.82);
-  --experience-section-bg: linear-gradient(160deg, rgba(99, 102, 241, 0.08), rgba(79, 70, 229, 0));
-  --experience-badge-bg: rgba(99, 102, 241, 0.15);
-  --experience-card-padding: clamp(1.35rem, 3vw, 2.15rem);
+  --timeline-accent: #6366f1;
+  --timeline-accent-soft: rgba(99, 102, 241, 0.18);
+  --timeline-card-bg: rgba(15, 23, 42, 0.05);
+  --timeline-card-border: rgba(99, 102, 241, 0.25);
+  --timeline-text-muted: rgba(15, 23, 42, 0.65);
   --timeline-dot-size: 18px;
   --timeline-dot-align: 0.125rem;
+  --timeline-heading-color: #0f172a;
+  --timeline-description-color: rgba(15, 23, 42, 0.82);
+  --timeline-section-bg: linear-gradient(160deg, rgba(99, 102, 241, 0.08), rgba(79, 70, 229, 0));
+  --timeline-card-padding: clamp(1.25rem, 3vw, 2rem);
+  --timeline-heading-offset: clamp(0.5rem, 1.2vw, 0.65rem);
 }
 
 :host-context(body.dark-mode) {
-  --experience-accent: #818cf8;
-  --experience-accent-soft: rgba(129, 140, 248, 0.24);
-  --experience-card-bg: rgba(30, 31, 38, 0.7);
-  --experience-card-highlight: rgba(129, 140, 248, 0.16);
-  --experience-card-border: rgba(129, 140, 248, 0.35);
-  --experience-card-shadow: 0 24px 55px rgba(15, 23, 42, 0.3);
-  --experience-text-muted: rgba(226, 232, 240, 0.7);
-  --experience-heading-color: #e2e8f0;
-  --experience-summary-color: rgba(226, 232, 240, 0.86);
-  --experience-section-bg: linear-gradient(160deg, rgba(129, 140, 248, 0.16), rgba(99, 102, 241, 0.08));
-  --experience-badge-bg: rgba(129, 140, 248, 0.18);
-}
-
-:host-context(body.blue-mode),
-:host-context(body.green-mode) {
-  --experience-accent: #6366f1;
-  --experience-accent-soft: rgba(99, 102, 241, 0.18);
-  --experience-card-highlight: rgba(99, 102, 241, 0.12);
-  --experience-card-border: rgba(99, 102, 241, 0.25);
-  --experience-section-bg: linear-gradient(160deg, rgba(99, 102, 241, 0.08), rgba(79, 70, 229, 0));
-  --experience-badge-bg: rgba(99, 102, 241, 0.15);
+  --timeline-accent: #818cf8;
+  --timeline-accent-soft: rgba(129, 140, 248, 0.24);
+  --timeline-card-bg: rgba(30, 31, 38, 0.7);
+  --timeline-card-border: rgba(129, 140, 248, 0.35);
+  --timeline-text-muted: rgba(226, 232, 240, 0.7);
+  --timeline-heading-color: #e2e8f0;
+  --timeline-description-color: rgba(226, 232, 240, 0.86);
+  --timeline-section-bg: linear-gradient(160deg, rgba(129, 140, 248, 0.16), rgba(79, 70, 229, 0.08));
 }
 
 .experiences-section {
@@ -45,21 +30,29 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  width: min(95vw, 100%);
-  background: var(--experience-section-bg);
+  background: var(--timeline-section-bg);
+  width: 100%;
+}
+
+.experiences-content {
+  width: min(80vw, 1200px);
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(2rem, 4vw, 3rem);
 }
 
 .experiences-title {
-  font-size: clamp(1.8rem, 3vw, 2.35rem);
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
   font-weight: 700;
-  margin-bottom: clamp(2rem, 4vw, 3rem);
   text-align: center;
+  margin: 0;
 }
 
 .timeline {
   --timeline-gap: clamp(1.75rem, 3vw, 2.75rem);
   width: 100%;
-  max-width: 1024px;
   display: grid;
   gap: var(--timeline-gap);
   margin: 0 auto;
@@ -67,7 +60,7 @@
 
 .timeline-item {
   display: grid;
-  grid-template-columns: 3.25rem 1fr;
+  grid-template-columns: 3.5rem 1fr;
   column-gap: clamp(1.25rem, 2.5vw, 2rem);
   align-items: start;
 }
@@ -79,7 +72,8 @@
   align-items: flex-start;
   align-self: stretch;
   padding-top: calc(
-    var(--experience-card-padding) - var(--timeline-dot-size) / 2 + var(--timeline-dot-align)
+    var(--timeline-card-padding) + var(--timeline-heading-offset) - var(--timeline-dot-size) / 2 +
+      var(--timeline-dot-align)
   );
 }
 
@@ -89,13 +83,13 @@
   top: 0;
   left: calc(50% - 1.5px);
   width: 3px;
-  bottom: calc(var(--timeline-gap) * -1.05);
-  background: linear-gradient(180deg, var(--experience-accent), rgba(99, 102, 241, 0));
+  bottom: calc(var(--timeline-gap) * -1.1);
+  background: linear-gradient(180deg, var(--timeline-accent), rgba(99, 102, 241, 0));
   border-radius: 999px;
 }
 
 .timeline-marker.is-last::before {
-  bottom: clamp(-1.25rem, -2.5vw, -0.65rem);
+  bottom: clamp(-1.5rem, -2.5vw, -1rem);
   opacity: 0.7;
 }
 
@@ -104,106 +98,79 @@
   width: var(--timeline-dot-size);
   height: var(--timeline-dot-size);
   border-radius: 50%;
-  background: var(--experience-accent);
-  box-shadow: 0 0 0 6px var(--experience-accent-soft), 0 12px 32px rgba(79, 70, 229, 0.18);
+  background: var(--timeline-accent);
+  box-shadow: 0 0 0 6px var(--timeline-accent-soft), 0 10px 30px rgba(79, 70, 229, 0.18);
 }
 
 .timeline-card {
-  position: relative;
-  background: linear-gradient(135deg, var(--experience-card-bg), var(--experience-card-highlight));
-  border: 1px solid var(--experience-card-border);
-  border-radius: 20px;
-  padding: var(--experience-card-padding);
-  box-shadow: var(--experience-card-shadow);
+  background: linear-gradient(135deg, var(--timeline-card-bg), rgba(99, 102, 241, 0.1));
+  border: 1px solid var(--timeline-card-border);
+  border-radius: 18px;
+  padding: var(--timeline-card-padding);
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
   backdrop-filter: blur(6px);
   display: flex;
   flex-direction: column;
-  gap: 0.85rem;
-  text-align: left;
-}
-
-.timeline-card::before {
-  content: "";
-  position: absolute;
-  inset: 0 auto 0 0;
-  width: 5px;
-  border-radius: 20px 0 0 20px;
-  background: linear-gradient(180deg, var(--experience-accent), rgba(79, 70, 229, 0));
+  gap: 0.75rem;
 }
 
 .timeline-header {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
   gap: 0.75rem;
-  align-items: start;
+  align-items: flex-start;
 }
 
 .timeline-heading {
   margin: 0;
-  font-size: clamp(1.1rem, 2.4vw, 1.45rem);
+  font-size: clamp(1.1rem, 2.4vw, 1.4rem);
   font-weight: 600;
-  color: var(--experience-heading-color);
+  text-align: left;
+  color: var(--timeline-heading-color);
+  line-height: 1.3;
 }
 
 .timeline-badge {
-  justify-self: end;
-  padding: 0.35rem 0.85rem;
+  padding: 0.35rem 0.75rem;
   border-radius: 999px;
-  background: var(--experience-badge-bg);
-  color: var(--experience-accent);
+  background: rgba(99, 102, 241, 0.15);
+  color: var(--timeline-accent);
   font-size: 0.85rem;
   font-weight: 600;
   letter-spacing: 0.02em;
-  white-space: nowrap;
 }
 
-.timeline-company {
-  margin: 0;
-  font-weight: 600;
-  color: var(--experience-heading-color);
-}
-
+.timeline-company,
 .timeline-location,
 .timeline-technologies {
   margin: 0;
   font-weight: 500;
-  color: var(--experience-text-muted);
+  color: var(--timeline-text-muted);
+  text-align: left;
 }
 
 .timeline-technologies {
-  font-style: italic;
+  font-weight: 600;
 }
 
 .timeline-summary {
   margin: 0;
-  line-height: 1.65;
-  color: var(--experience-summary-color);
+  line-height: 1.6;
+  color: var(--timeline-description-color);
+  text-align: left;
 }
 
 .timeline-responsibilities {
   margin: 0;
   padding-left: 1.25rem;
   display: grid;
-  gap: 0.55rem;
-  color: var(--experience-summary-color);
+  gap: 0.5rem;
+  color: var(--timeline-description-color);
 }
 
 .timeline-responsibilities li {
-  line-height: 1.55;
-}
-
-@media (max-width: 992px) {
-  .timeline-item {
-    grid-template-columns: 2.85rem 1fr;
-  }
-
-  .timeline-header {
-    grid-template-columns: 1fr;
-  }
-
-  .timeline-badge {
-    justify-self: flex-start;
-  }
+  line-height: 1.6;
 }
 
 @media (max-width: 768px) {
@@ -212,32 +179,40 @@
     width: 100%;
   }
 
+  .experiences-content {
+    width: 100%;
+  }
+
   .timeline-item {
-    grid-template-columns: 2.5rem 1fr;
+    grid-template-columns: 2.75rem 1fr;
+  }
+
+  .timeline-badge {
+    font-size: 0.8rem;
   }
 }
 
 @media (max-width: 600px) {
   .experiences-section {
     padding: clamp(2rem, 6vw, 3.5rem) clamp(1rem, 4vw, 2rem);
-    width: 100%;
   }
 
-  .timeline {
-    --timeline-gap: clamp(1.35rem, 4vw, 1.85rem);
+  .experiences-content {
+    width: 100%;
   }
 
   .timeline-item {
     position: relative;
     grid-template-columns: 1fr;
-    row-gap: 1.1rem;
+    row-gap: 1rem;
     padding-left: 2.5rem;
   }
 
   .timeline-marker {
     position: absolute;
     inset: calc(
-        var(--experience-card-padding) - var(--timeline-dot-size) / 2 + var(--timeline-dot-align)
+        var(--timeline-card-padding) + var(--timeline-heading-offset) - var(--timeline-dot-size) / 2 +
+        var(--timeline-dot-align)
       )
       auto auto 0;
     width: 2.5rem;
@@ -251,5 +226,11 @@
 
   .timeline-dot {
     margin-top: 0;
+  }
+}
+
+@media (min-width: 992px) {
+  .experiences-content {
+    width: min(80vw, 1200px);
   }
 }


### PR DESCRIPTION
## Summary
- wrap the experience timeline content in a centered container consistent with the education section
- restyle the experience timeline markers, cards, and text to match the education UI and align dots with the headings

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e50bb9626c832b8382ca2267bb9735