### PR TITLE
Adjust overlay container z-index for tooltips

### DIFF
--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -99,6 +99,6 @@ mat-error {
 }
 
 // Ensure Material tooltips appear above every other UI element, including the assistant overlay
-.mat-mdc-tooltip-panel {
+.cdk-overlay-container {
     z-index: 2147483647 !important;
 }


### PR DESCRIPTION
## Summary
- raise the Angular CDK overlay container z-index so Material tooltips can render above the assistant controls

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e56be3aa4c832bbe53da05d8c49e6c