### PR TITLE
Update navigator toggle test for integrated close button

### DIFF
--- a/src/app/components/navigator/navigator.component.spec.ts
+++ b/src/app/components/navigator/navigator.component.spec.ts
@@ -63,7 +63,9 @@ describe('NavigatorComponent', () => {
     component.showThemeOptions = true;
     fixture.detectChanges();
 
-    const toggleButton: HTMLButtonElement = fixture.nativeElement.querySelector('.nav-toggle-button');
+    const toggleButton: HTMLButtonElement = fixture.nativeElement.querySelector('.close-button');
+    expect(toggleButton).withContext('Integrated close/toggle button should be present when navigator is open').toBeTruthy();
+
     toggleButton.click();
     fixture.detectChanges();
 


### PR DESCRIPTION
## Summary
- update the navigator toggle unit test to query the integrated close button selector
- assert the toggle button exists before attempting to click it to avoid null dereferences

## Testing
- not run (npm install fails in CI environment)


------
https://chatgpt.com/codex/tasks/task_e_68e56bf0b1e4832bb467f2adc5315b71