### PR TITLE
Fix assistant spec timer handling

### DIFF
--- a/src/app/components/assistant/assistant.component.spec.ts
+++ b/src/app/components/assistant/assistant.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, flush, tick } from '@angular/core/testing';
 import { AssistantComponent } from './assistant.component';
 import { TranslationService } from '../../services/translation.service';
 import { MockTranslationService } from '../../testing/mock-translation.service';
@@ -31,12 +31,12 @@ describe('AssistantComponent', () => {
     component.opened.subscribe(openedSpy);
 
     component.openAssistant();
-    tick();
 
     expect(component.isOpen).toBeTrue();
     expect(component.animationPhase).toBe('wondering');
     expect(openedSpy).toHaveBeenCalled();
 
+    flush();
     component.closeAssistant();
     tick();
   }));


### PR DESCRIPTION
## Summary
- import the flush helper in the assistant component spec
- flush the fakeAsync timer in the assistant opening test to clear the pending timeout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e56bf5cf00832b908d839af7b97a7b