### PR TITLE
Handle ongoing experience end dates in stats calculation

### DIFF
--- a/src/app/components/stats/stats.component.ts
+++ b/src/app/components/stats/stats.component.ts
@@ -145,7 +145,17 @@ export class StatsComponent implements OnInit, OnDestroy {
    */
   calculateMonths(start: string, end: string): number {
     const startDate = new Date(start);
-    const endDate = new Date(end);
+    let endDate: Date;
+
+    if (typeof end === 'string' && end.trim().toLowerCase() === 'current') {
+      endDate = new Date();
+    } else {
+      endDate = new Date(end);
+      if (Number.isNaN(endDate.getTime())) {
+        endDate = new Date();
+      }
+    }
+
     return (endDate.getFullYear() - startDate.getFullYear()) * 12 + (endDate.getMonth() - startDate.getMonth()) + 1;
   }
 }


### PR DESCRIPTION
## Summary
- update stats month calculation to treat "Current" end dates as the present day
- fall back to the current date when an experience end date cannot be parsed

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e56c32b094832b81339c1c9711b7e9