### PR TITLE
Fix stats numeric formatting stability on language change

### DIFF
--- a/src/app/components/stats/stats.component.ts
+++ b/src/app/components/stats/stats.component.ts
@@ -39,6 +39,7 @@ export class StatsComponent implements OnInit, OnDestroy {
   isLoading = true;
 
   private readonly destroy$ = new Subject<void>();
+  private metricsCache: StatsMetrics | null = null;
 
   constructor(private translationService: TranslationService) { }
 
@@ -55,11 +56,13 @@ export class StatsComponent implements OnInit, OnDestroy {
           const statsTemplateSource = this.resolveLocalizedContent(statsData);
           const baseTemplate = statsTemplateSource.content;
 
-          const computed = this.calculateStats(
-            experiencesSource.content.experiences,
-            projectsSource.content.projects,
-            statsTemplateSource.language,
-            baseTemplate
+          const computed = this.metricsCache ?? (
+            this.metricsCache = this.calculateStats(
+              experiencesSource.content.experiences,
+              projectsSource.content.projects,
+              statsTemplateSource.language,
+              baseTemplate
+            )
           );
 
           const translatableTemplate = this.buildTranslatableTemplate(baseTemplate);


### PR DESCRIPTION
## Summary
- cache the computed stats metrics so numeric values are formatted only once
- reuse cached metrics when translating labels to keep the displayed numbers stable across languages

## Testing
- npm test -- stats *(fails: ng not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e56bf10060832bb794a4cb93acc2fe