### PR TITLE
Update project description toggle unit test coverage

### DIFF
--- a/src/app/components/projects/projects.component.spec.ts
+++ b/src/app/components/projects/projects.component.spec.ts
@@ -68,6 +68,8 @@ describe('ProjectsComponent', () => {
 
     expect(description.classList.contains('expanded')).toBeFalse();
     expect(toggleButton.getAttribute('aria-expanded')).toBe('false');
+    expect(toggleButton.textContent?.trim()).toBe(component.projects.moreDesc);
+    expect(toggleButton.getAttribute('aria-controls')).toBe(description.getAttribute('id'));
 
     toggleButton.click();
     fixture.detectChanges();
@@ -75,6 +77,7 @@ describe('ProjectsComponent', () => {
     expect(firstProject.expanded).toBeTrue();
     expect(description.classList.contains('expanded')).toBeTrue();
     expect(toggleButton.getAttribute('aria-expanded')).toBe('true');
+    expect(toggleButton.textContent?.trim()).toBe(component.projects.lessDesc);
   });
 
   /**


### PR DESCRIPTION
## Summary
- extend the ProjectsComponent unit tests to cover the DOM state changes after toggling the CSS-clamped description

## Testing
- npm test -- --watch=false *(fails: sh: 1: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e56c330fb0832ba665a492fb8a7684