### PR TITLE
Fix social component localization

### DIFF
--- a/src/app/components/social/social.component.html
+++ b/src/app/components/social/social.component.html
@@ -1,5 +1,5 @@
 <div class="social-container">
-    <div class="social-item" *ngFor="let social of socialsData">
+    <div class="social-item" *ngFor="let social of (socials$ | async) ?? []">
         <a
             [href]="social.link"
             target="_blank"
@@ -7,7 +7,7 @@
             [attr.aria-label]="social.label"
             [title]="social.label"
         >
-            <img [src]="social.icon" [alt]="'Icona ' + social.label" />
+            <img [src]="social.icon" [alt]="social.label" />
         </a>
     </div>
 </div>

--- a/src/app/components/social/social.component.spec.ts
+++ b/src/app/components/social/social.component.spec.ts
@@ -1,6 +1,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { SocialComponent } from './social.component';
+import { firstValueFrom } from 'rxjs';
+
 import { Social } from '../../dtos/SocialDTO';
+import { TranslationService } from '../../services/translation.service';
+import { MockTranslationService } from '../../testing/mock-translation.service';
 
 /**
  * Unit tests for SocialComponent.
@@ -14,7 +18,8 @@ describe('SocialComponent', () => {
    */
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [SocialComponent]
+      imports: [SocialComponent],
+      providers: [{ provide: TranslationService, useClass: MockTranslationService }]
     }).compileComponents();
 
     fixture = TestBed.createComponent(SocialComponent);
@@ -32,15 +37,17 @@ describe('SocialComponent', () => {
   /**
    * Verifies that the social media data is populated correctly.
    */
-  it('should expose social media data as an array', () => {
-    expect(Array.isArray(component.socialsData)).toBeTrue();
+  it('should expose social media data as an array', async () => {
+    const socials = await firstValueFrom(component.socials$);
+    expect(Array.isArray(socials)).toBeTrue();
   });
 
   /**
    * Verifies the structure of a social media object.
    */
-  it('should contain valid social media objects', () => {
-    component.socialsData.forEach((social: Social) => {
+  it('should contain valid social media objects', async () => {
+    const socials = await firstValueFrom(component.socials$);
+    socials.forEach((social: Social) => {
       expect(social.link).toBeDefined();
       expect(social.icon).toBeDefined();
       expect(typeof social.link).toBe('string');
@@ -51,8 +58,9 @@ describe('SocialComponent', () => {
   /**
    * Verifies that the social media data contains valid objects.
    */
-  it('should contain valid social objects with link and icon properties', () => {
-    component.socialsData.forEach((social: Social) => {
+  it('should contain valid social objects with link and icon properties', async () => {
+    const socials = await firstValueFrom(component.socials$);
+    socials.forEach((social: Social) => {
       expect(social).toEqual(jasmine.objectContaining({
         link: jasmine.any(String),
         icon: jasmine.any(String)

--- a/src/app/components/social/social.component.ts
+++ b/src/app/components/social/social.component.ts
@@ -1,7 +1,11 @@
 import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Observable } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
+
 import { Social } from '../../dtos/SocialDTO';
 import { socials } from '../../data/socials.data';
-import { CommonModule } from '@angular/common';
+import { TranslationService } from '../../services/translation.service';
 
 /**
  * Displays a list of social media links with icons.
@@ -14,5 +18,11 @@ import { CommonModule } from '@angular/common';
   styleUrls: ['./social.component.scss']
 })
 export class SocialComponent {
-  socialsData: Social[] = socials;
+  readonly socials$: Observable<Social[]>;
+
+  constructor(private readonly translationService: TranslationService) {
+    this.socials$ = this.translationService.currentLanguage$.pipe(
+      switchMap(() => this.translationService.translateContent<Social[]>(socials, 'en'))
+    );
+  }
 }

--- a/src/app/data/socials.data.ts
+++ b/src/app/data/socials.data.ts
@@ -4,16 +4,16 @@ export const socials: Social[] = [
     {
         link: 'https://linkedin.com/in/diegofois/',
         icon: 'https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/linkedin.svg',
-        label: 'Profilo LinkedIn'
+        label: 'LinkedIn profile'
     },
     {
         link: 'https://github.com/DiegoFCJ',
         icon: 'https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/github.svg',
-        label: 'Repository GitHub'
+        label: 'GitHub repository'
     },
     {
         link: 'https://discord.com/users/diegofcj',
         icon: 'https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/discord.svg',
-        label: 'Profilo Discord'
+        label: 'Discord profile'
     }
 ];


### PR DESCRIPTION
## Summary
- restore English base copy for social link metadata so translations can adapt to the selected language
- translate social link labels at runtime through TranslationService and update the template to bind to localized observables
- refresh the social component unit tests to use the translation mock and assert against localized data

## Testing
- `npm test -- --watch=false` *(fails: ng: not found because Angular CLI isn't installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e56bf804ac832b858b2a9572431292