### PR TITLE
Fix stats mapping for updated metrics

### DIFF
--- a/src/app/components/stats/stats.component.spec.ts
+++ b/src/app/components/stats/stats.component.spec.ts
@@ -37,9 +37,9 @@ describe('StatsComponent', () => {
   it('should prepare statistics correctly', () => {
     component.ngOnInit();
     expect(component.statistics.length).toBe(4);
-    expect(component.statistics[0].label).toBe('Total Hours');
-    expect(component.statistics[1].label).toBe('Experience Months');
-    expect(component.statistics[2].label).toBe('Projects Delivered');
+    expect(component.statistics[0].label).toBe('Total Months');
+    expect(component.statistics[1].label).toBe('Projects Delivered');
+    expect(component.statistics[2].label).toBe('Processes Automated');
     expect(component.statistics[3].label).toBe('Core Stack');
   });
 
@@ -52,10 +52,10 @@ describe('StatsComponent', () => {
       projects.en.projects
     );
 
-    expect(stats.hours).toBe('7080+ engineering hours delivered');
-    expect(stats.months).toBe('44+ months across enterprise projects');
-    expect(stats.projects).toBe('8 end-to-end initiatives led');
-    expect(stats.mostUsed).toContain('·');
+    expect(stats.months).toBe('44+ months delivering value');
+    expect(stats.projects).toBe('8 projects delivered');
+    expect(stats.automations).toBe('3+ processes automated');
+    expect(stats.coreStack).toContain('·');
   });
 
   /**
@@ -93,18 +93,18 @@ describe('StatsComponent', () => {
    */
   it('should populate statistics array', () => {
     component.stats = {
-      hours: '4000 hours',
       months: '24 months',
       projects: '12 projects',
-      mostUsed: 'Java, Angular, SQL, Node.js'
+      automations: '5 automations',
+      coreStack: 'Java, Angular, SQL, Node.js'
     };
 
     component.prepareStatistics('en');
 
     expect(component.statistics.length).toBe(4);
-    expect(component.statistics[0].value).toBe('4000 hours');
-    expect(component.statistics[1].value).toBe('24 months');
-    expect(component.statistics[2].value).toBe('12 projects');
+    expect(component.statistics[0].value).toBe('24 months');
+    expect(component.statistics[1].value).toBe('12 projects');
+    expect(component.statistics[2].value).toBe('5 automations');
     expect(component.statistics[3].value).toBe('Java, Angular, SQL, Node.js');
   });
 });

--- a/src/app/components/stats/stats.component.ts
+++ b/src/app/components/stats/stats.component.ts
@@ -19,10 +19,10 @@ import { statsData } from '../../data/stats.data';
 })
 export class StatsComponent implements OnInit {
   stats: StatsItem = {
-    hours: "",
     months: "",
     projects: "",
-    mostUsed: ""
+    automations: "",
+    coreStack: ""
   };
   statsTitle: string = "";
   statistics: Stat[] = []
@@ -43,19 +43,9 @@ export class StatsComponent implements OnInit {
     const labels = statsData[language]?.stats;
 
     if (labels) {
-      this.statistics = labels.map((stat, index) => {
-        switch (index) {
-          case 0:
-            return { ...stat, value: this.stats.hours };
-          case 1:
-            return { ...stat, value: this.stats.months };
-          case 2:
-            return { ...stat, value: this.stats.projects };
-          case 3:
-            return { ...stat, value: this.stats.mostUsed };
-          default:
-            return stat;
-        }
+      this.statistics = labels.map((stat) => {
+        const metricValue = stat.metric ? this.stats[stat.metric] : undefined;
+        return metricValue ? { ...stat, value: metricValue } : stat;
       });
     } else {
       console.error(`Language ${language} not found in statsLabels.`);
@@ -63,10 +53,10 @@ export class StatsComponent implements OnInit {
   }
 
   calculateStats(experiences: any[], projectList: any[]): StatsItem {
-    let totalHours = 0;
     let totalMonths = 0;
     let totalProjects = projectList.length;
     let technologyCount: { [key: string]: number } = {};
+    let automationCount = 0;
 
     const experiencesWithTechnologies = experiences.filter(exp => exp.technologies?.trim().length);
     totalProjects += experiencesWithTechnologies.length;
@@ -75,15 +65,9 @@ export class StatsComponent implements OnInit {
       const months = this.calculateMonths(exp.startDate, exp.endDate);
       totalMonths += months;
 
-      const weeks = months * 4;
-      const hoursWorkedPerWeek = 40;
-      let hoursWorked = weeks * hoursWorkedPerWeek;
-
-      if (index === experiencesWithTechnologies.length - 1) {
-        hoursWorked += hoursWorkedPerWeek; // add one week of hours
-      }
-
-      totalHours += hoursWorked;
+      const responsibilities = exp.responsibilities ?? "";
+      const automationMatches = responsibilities.match(/automat(?:ed|es|ing|ion)?/gi);
+      automationCount += automationMatches ? automationMatches.length : 0;
 
       const technologies = exp.technologies.split(', ').map(this.normalizeTechnology);
       technologies.forEach((tech: any) => {
@@ -97,10 +81,10 @@ export class StatsComponent implements OnInit {
       .map(([tech]) => this.formatTechnology(tech));
 
     return {
-      hours: `${Math.round(totalHours)}+ engineering hours delivered`,
-      months: `${totalMonths}+ months across enterprise projects`,
-      projects: `${totalProjects} end-to-end initiatives led`,
-      mostUsed: sortedTechnologies.join(' · ')
+      months: `${totalMonths}+ months delivering value`,
+      projects: `${totalProjects} projects delivered`,
+      automations: `${automationCount}+ processes automated`,
+      coreStack: sortedTechnologies.join(' · ')
     };
   }
 

--- a/src/app/data/stats.data.ts
+++ b/src/app/data/stats.data.ts
@@ -4,37 +4,37 @@ export const statsData: Stats = {
     en: {
         title: 'Statistics',
         stats: [
-            { icon: 'schedule', label: 'Total Hours', value: '7K+ engineering hours' },
-            { icon: 'today', label: 'Experience Months', value: '44+ months delivering value' },
-            { icon: 'work', label: 'Projects Delivered', value: '8 end-to-end initiatives' },
-            { icon: 'code', label: 'Core Stack', value: 'Spring Boot · Java · Angular · SQL Server' },
+            { icon: 'today', label: 'Total Months', value: '44+ months delivering value', metric: 'months' },
+            { icon: 'work', label: 'Projects Delivered', value: '8 projects delivered', metric: 'projects' },
+            { icon: 'settings', label: 'Processes Automated', value: '3+ processes automated', metric: 'automations' },
+            { icon: 'code', label: 'Core Stack', value: 'Spring Boot · Java · Angular · SQL Server', metric: 'coreStack' },
         ]
     },
     it: {
         title: 'Statistiche',
         stats: [
-            { icon: 'schedule', label: 'Ore Totali', value: 'Oltre 7K ore di sviluppo' },
-            { icon: 'today', label: 'Mesi di Esperienza', value: '44+ mesi di risultati' },
-            { icon: 'work', label: 'Progetti Consegnati', value: '8 iniziative end-to-end' },
-            { icon: 'code', label: 'Stack Principale', value: 'Spring Boot · Java · Angular · SQL Server' },
+            { icon: 'today', label: 'Mesi Totali', value: '44+ mesi di risultati', metric: 'months' },
+            { icon: 'work', label: 'Progetti Consegnati', value: '8 progetti consegnati', metric: 'projects' },
+            { icon: 'settings', label: 'Processi Automatizzati', value: '3+ processi automatizzati', metric: 'automations' },
+            { icon: 'code', label: 'Stack Principale', value: 'Spring Boot · Java · Angular · SQL Server', metric: 'coreStack' },
         ]
     },
     de: {
         title: 'Statistiken',
         stats: [
-            { icon: 'schedule', label: 'Gesamtstunden', value: 'Über 7K Stunden Engineering' },
-            { icon: 'today', label: 'Erfahrungsmonate', value: '44+ Monate mit Mehrwert' },
-            { icon: 'work', label: 'Gelieferte Projekte', value: '8 End-to-End-Initiativen' },
-            { icon: 'code', label: 'Kerntechnologien', value: 'Spring Boot · Java · Angular · SQL Server' },
+            { icon: 'today', label: 'Gesamtmonate', value: '44+ Monate mit Mehrwert', metric: 'months' },
+            { icon: 'work', label: 'Gelieferte Projekte', value: '8 gelieferte Projekte', metric: 'projects' },
+            { icon: 'settings', label: 'Automatisierte Prozesse', value: '3+ automatisierte Prozesse', metric: 'automations' },
+            { icon: 'code', label: 'Kerntechnologien', value: 'Spring Boot · Java · Angular · SQL Server', metric: 'coreStack' },
         ]
     },
     es: {
         title: 'Estadísticas',
         stats: [
-            { icon: 'schedule', label: 'Horas Totales', value: 'Más de 7K horas de ingeniería' },
-            { icon: 'today', label: 'Meses de Experiencia', value: '44+ meses generando impacto' },
-            { icon: 'work', label: 'Proyectos Entregados', value: '8 iniciativas end-to-end' },
-            { icon: 'code', label: 'Tecnologías Clave', value: 'Spring Boot · Java · Angular · SQL Server' },
+            { icon: 'today', label: 'Meses Totales', value: '44+ meses generando impacto', metric: 'months' },
+            { icon: 'work', label: 'Proyectos Entregados', value: '8 proyectos entregados', metric: 'projects' },
+            { icon: 'settings', label: 'Procesos Automatizados', value: '3+ procesos automatizados', metric: 'automations' },
+            { icon: 'code', label: 'Tecnologías Clave', value: 'Spring Boot · Java · Angular · SQL Server', metric: 'coreStack' },
         ]
     }
 };

--- a/src/app/dtos/StatsDTO.ts
+++ b/src/app/dtos/StatsDTO.ts
@@ -11,15 +11,19 @@ export interface StatsFull {
     stats: Stat[];
 }
 
+export type StatsMetric = 'months' | 'projects' | 'automations' | 'coreStack';
+
 export interface Stat {
     icon: string;
     value: string;
     label: string;
+    metric: StatsMetric;
 }
 
 export interface StatsItem {
-    hours: string;
     months: string;
     projects: string;
-    mostUsed: string;
+    automations: string;
+    coreStack: string;
+    [key: string]: string;
 }


### PR DESCRIPTION
## Summary
- add metric keys to stats data and realign translations around months, projects, automations, and core stack
- compute the new metrics in StatsComponent and map statistics by metric instead of array order
- refresh DTO typings and unit tests to reflect the new statistics fields

## Testing
- npm run test -- --watch=false --include src/app/components/stats/stats.component.spec.ts *(fails: ng not found in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e56c2ef828832bbe7b7f725f35f9b4