### PR TITLE
Improve responsive layout across sections

### DIFF
--- a/src/app/components/about/about.component.scss
+++ b/src/app/components/about/about.component.scss
@@ -9,6 +9,9 @@
     --about-highlight-border: rgba(99, 102, 241, 0.25);
     --about-highlight-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
     --about-section-bg: linear-gradient(160deg, rgba(99, 102, 241, 0.08), rgba(79, 70, 229, 0));
+    display: block;
+    inline-size: 100%;
+    block-size: 100%;
 }
 
 :host-context(body.dark-mode) {
@@ -27,12 +30,15 @@
 .about-section {
     position: relative;
     z-index: 6;
-    min-height: 100vh;
+    inline-size: 100%;
+    block-size: 100%;
+    min-block-size: 100%;
     display: flex;
     justify-content: center;
     align-items: center;
     padding: clamp(2.5rem, 6vw, 5rem) clamp(1.25rem, 5vw, 4rem);
     background: var(--about-section-bg);
+    overflow: auto;
 }
 
 .about-container {

--- a/src/app/components/assistant/assistant.component.spec.ts
+++ b/src/app/components/assistant/assistant.component.spec.ts
@@ -40,7 +40,8 @@ describe('AssistantComponent', () => {
     expect(component.animationPhase).toBe('waking');
     expect(openedSpy).toHaveBeenCalled();
 
-    flush();
+    tick(ASSISTANT_WAKE_DURATION_MS + ASSISTANT_JUMP_DURATION_MS);
+
     component.closeAssistant();
     tick();
   }));

--- a/src/app/components/contact-me/contact-me.component.html
+++ b/src/app/components/contact-me/contact-me.component.html
@@ -8,7 +8,7 @@
           <div class="card-support">
             <div class="popup-relativeness">
               <app-social></app-social>
-              <app-custom-popup [message]="popupMessage" [width]="'40vw'" [top]="'-15px'"></app-custom-popup>
+              <app-custom-popup [message]="popupMessage" [width]="'min(320px, 80vw)'" [top]="'-15px'"></app-custom-popup>
             </div>
           </div>
         </header>

--- a/src/app/components/contact-me/contact-me.component.scss
+++ b/src/app/components/contact-me/contact-me.component.scss
@@ -1,3 +1,9 @@
+:host {
+  display: block;
+  inline-size: 100%;
+  block-size: 100%;
+}
+
 .contact-me-section {
   --contact-card-bg: linear-gradient(135deg, rgba(236, 239, 255, 0.9), rgba(219, 234, 254, 0.65));
   --contact-card-border: rgba(99, 102, 241, 0.28);
@@ -18,7 +24,9 @@
   --contact-status-error-text: #b91c1c;
   --contact-card-padding: clamp(1.5rem, 4vw, 2.25rem);
 
-  min-height: 100vh;
+  inline-size: 100%;
+  block-size: 100%;
+  min-block-size: 100%;
   margin: 0 auto;
   padding: clamp(2rem, 5vw, 4rem) clamp(1.5rem, 4vw, 3rem);
   display: flex;
@@ -28,6 +36,7 @@
   width: min(100%, 38rem);
   text-align: center;
   background: linear-gradient(160deg, rgba(99, 102, 241, 0.08), rgba(79, 70, 229, 0));
+  overflow: auto;
 }
 
 body.dark-mode .contact-me-section {

--- a/src/app/components/contact-me/contact-me.component.scss
+++ b/src/app/components/contact-me/contact-me.component.scss
@@ -25,7 +25,7 @@
   flex-direction: column;
   align-items: center;
   gap: clamp(1.75rem, 4vw, 2.75rem);
-  width: min(92vw, 100%);
+  width: min(100%, 38rem);
   text-align: center;
   background: linear-gradient(160deg, rgba(99, 102, 241, 0.08), rgba(79, 70, 229, 0));
 }
@@ -191,7 +191,7 @@ body.dark-mode .contact-me-section {
 
 @media (min-width: 768px) {
   .contact-me-section {
-    width: min(80vw, 600px);
+    width: min(85vw, 38rem);
   }
 }
 
@@ -203,6 +203,6 @@ body.dark-mode .contact-me-section {
 
 @media (max-width: 620px) {
   .contact-me-section {
-    width: min(95vw, 100%);
+    width: min(95vw, 38rem);
   }
 }

--- a/src/app/components/education/education.component.scss
+++ b/src/app/components/education/education.component.scss
@@ -11,6 +11,9 @@
   --timeline-section-bg: linear-gradient(160deg, rgba(99, 102, 241, 0.08), rgba(79, 70, 229, 0));
   --timeline-card-padding: clamp(1.25rem, 3vw, 2rem);
   --timeline-heading-offset: clamp(0.5rem, 1.2vw, 0.65rem);
+  display: block;
+  inline-size: 100%;
+  block-size: 100%;
 }
 
 :host-context(body.dark-mode) {
@@ -25,13 +28,16 @@
 }
 
 .education-section {
-  min-height: 100vh;
+  inline-size: 100%;
+  block-size: 100%;
+  min-block-size: 100%;
   padding: clamp(2rem, 4vw, 4.5rem) clamp(1.5rem, 5vw, 3.5rem);
   display: flex;
   flex-direction: column;
   align-items: center;
   background: var(--timeline-section-bg);
   width: 100%;
+  overflow: auto;
 }
 
 .education-content {

--- a/src/app/components/education/education.component.scss
+++ b/src/app/components/education/education.component.scss
@@ -26,7 +26,7 @@
 
 .education-section {
   min-height: 100vh;
-  padding: clamp(2rem, 4vw, 4.5rem) clamp(1.25rem, 3vw, 3rem);
+  padding: clamp(2rem, 4vw, 4.5rem) clamp(1.5rem, 5vw, 3.5rem);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -35,11 +35,12 @@
 }
 
 .education-content {
-  width: min(80vw, 1200px);
+  width: min(100%, 70rem);
   margin: 0 auto;
   display: flex;
   flex-direction: column;
   align-items: center;
+  padding-inline: clamp(1rem, 4vw, 2.75rem);
 }
 
 .education-title {
@@ -51,7 +52,7 @@
 
 .timeline {
   --timeline-gap: clamp(1.75rem, 3vw, 2.75rem);
-  width: min(80%, 1024px);
+  width: min(100%, 60rem);
   display: grid;
   gap: var(--timeline-gap);
   margin: 0 auto;
@@ -157,10 +158,6 @@
 @media (max-width: 768px) {
   .timeline {
     --timeline-gap: clamp(1.5rem, 4vw, 2rem);
-    width: 90%;
-  }
-
-  .education-content {
     width: 100%;
   }
 
@@ -175,15 +172,12 @@
 
 @media (max-width: 600px) {
   .education-section {
-    padding: clamp(2rem, 6vw, 3.5rem) clamp(1rem, 4vw, 2rem);
+    padding: clamp(2rem, 6vw, 3.5rem) clamp(1.25rem, 5vw, 2.5rem);
   }
 
   .education-content {
     width: 100%;
-  }
-
-  .timeline {
-    width: 90%;
+    padding-inline: clamp(1rem, 6vw, 2.25rem);
   }
 
   .timeline-item {
@@ -216,6 +210,6 @@
 
 @media (min-width: 992px) {
   .education-content {
-    width: min(80vw, 1200px);
+    max-width: 70rem;
   }
 }

--- a/src/app/components/experiences/experiences.component.scss
+++ b/src/app/components/experiences/experiences.component.scss
@@ -11,6 +11,9 @@
   --timeline-section-bg: linear-gradient(160deg, rgba(99, 102, 241, 0.08), rgba(79, 70, 229, 0));
   --timeline-card-padding: clamp(1.25rem, 3vw, 2rem);
   --timeline-heading-offset: clamp(0.5rem, 1.2vw, 0.65rem);
+  display: block;
+  inline-size: 100%;
+  block-size: 100%;
 }
 
 :host-context(body.dark-mode) {
@@ -25,13 +28,16 @@
 }
 
 .experiences-section {
-  min-height: 100vh;
+  inline-size: 100%;
+  block-size: 100%;
+  min-block-size: 100%;
   padding: clamp(2rem, 4vw, 4.5rem) clamp(1.5rem, 5vw, 3.5rem);
   display: flex;
   flex-direction: column;
   align-items: center;
   background: var(--timeline-section-bg);
   width: 100%;
+  overflow: auto;
 }
 
 .experiences-content {

--- a/src/app/components/experiences/experiences.component.scss
+++ b/src/app/components/experiences/experiences.component.scss
@@ -26,7 +26,7 @@
 
 .experiences-section {
   min-height: 100vh;
-  padding: clamp(2rem, 4vw, 4.5rem) clamp(1.25rem, 3vw, 3rem);
+  padding: clamp(2rem, 4vw, 4.5rem) clamp(1.5rem, 5vw, 3.5rem);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -35,12 +35,13 @@
 }
 
 .experiences-content {
-  width: min(80vw, 1200px);
+  width: min(100%, 70rem);
   margin: 0 auto;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: clamp(2rem, 4vw, 3rem);
+  padding-inline: clamp(1rem, 4vw, 2.75rem);
 }
 
 .experiences-title {
@@ -176,10 +177,6 @@
 @media (max-width: 768px) {
   .timeline {
     --timeline-gap: clamp(1.5rem, 4vw, 2rem);
-    width: 90%;
-  }
-
-  .experiences-content {
     width: 100%;
   }
 
@@ -194,11 +191,12 @@
 
 @media (max-width: 600px) {
   .experiences-section {
-    padding: clamp(2rem, 6vw, 3.5rem) clamp(1rem, 4vw, 2rem);
+    padding: clamp(2rem, 6vw, 3.5rem) clamp(1.25rem, 5vw, 2.5rem);
   }
 
   .experiences-content {
     width: 100%;
+    padding-inline: clamp(1rem, 6vw, 2.25rem);
   }
 
   .timeline-item {
@@ -231,6 +229,6 @@
 
 @media (min-width: 992px) {
   .experiences-content {
-    width: min(80vw, 1200px);
+    max-width: 70rem;
   }
 }

--- a/src/app/components/hero/hero.component.scss
+++ b/src/app/components/hero/hero.component.scss
@@ -1,6 +1,8 @@
 :host {
   position: relative;
   display: block;
+  inline-size: 100%;
+  block-size: 100%;
 }
 
 .bg-container {
@@ -10,9 +12,10 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  min-height: 80vh;
-  height: 100%;
+  block-size: 100%;
+  min-block-size: 100%;
   text-align: center;
+  overflow: auto;
 }
 
 .bottom-border {
@@ -42,9 +45,9 @@
 @media (max-width: 768px) {
   .bg-container {
     padding: 0 1em;
-    min-height: 85vh;
-    height: auto;
-    padding-bottom: 10vh;
+    block-size: 100%;
+    min-block-size: 100%;
+    padding-bottom: 2rem;
   }
 
   .hero-content {

--- a/src/app/components/projects/projects.carousel.component.scss
+++ b/src/app/components/projects/projects.carousel.component.scss
@@ -1,10 +1,12 @@
 // Carosello per dispositivi mobili
 .carousel-container {
-    width: min(92vw, 420px);
+    width: min(100%, 420px);
     margin: 0 auto;
     display: flex;
     flex-direction: column;
     gap: 1.1rem;
+    padding-inline: clamp(0.5rem, 5vw, 1.5rem);
+    box-sizing: border-box;
 }
 
 .carousel-viewport {
@@ -24,7 +26,7 @@
 .carousel-wrapper {
     display: flex;
     gap: 1.15rem;
-    padding-inline: 0.5rem 1.5rem;
+    padding-inline: clamp(0.25rem, 3vw, 0.75rem) clamp(0.75rem, 6vw, 1.5rem);
     transition: transform 0.6s ease;
 }
 

--- a/src/app/components/projects/projects.component.scss
+++ b/src/app/components/projects/projects.component.scss
@@ -8,12 +8,17 @@
     --projects-status-active: linear-gradient(135deg, rgba(56, 189, 248, 0.45), rgba(14, 165, 233, 0.75));
     --projects-status-publicBeta: linear-gradient(135deg, rgba(129, 140, 248, 0.45), rgba(99, 102, 241, 0.7));
     --projects-status-inDevelopment: linear-gradient(135deg, rgba(251, 191, 36, 0.4), rgba(245, 158, 11, 0.72));
+    display: block;
+    inline-size: 100%;
+    block-size: 100%;
 }
 
 .projects-section {
   position: relative;
   z-index: 5;
-  min-height: 100vh;
+  inline-size: 100%;
+  block-size: 100%;
+  min-block-size: 100%;
   padding: clamp(2.5rem, 6vw, 4.75rem) clamp(1.5rem, 5vw, 3.5rem);
   display: flex;
   flex-direction: column;
@@ -22,6 +27,7 @@
   background: linear-gradient(160deg, rgba(56, 189, 248, 0.12), rgba(56, 189, 248, 0));
   width: min(100%, 70rem);
   margin: 0 auto;
+  overflow: auto;
 }
 
 .projects-title {

--- a/src/app/components/projects/projects.component.scss
+++ b/src/app/components/projects/projects.component.scss
@@ -11,15 +11,17 @@
 }
 
 .projects-section {
-    position: relative;
-    z-index: 5;
-    min-height: 100vh;
-    padding: clamp(2.5rem, 6vw, 4.75rem) clamp(1.5rem, 4vw, 3.25rem);
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: clamp(2rem, 5vw, 3.5rem);
-    background: linear-gradient(160deg, rgba(56, 189, 248, 0.12), rgba(56, 189, 248, 0));
+  position: relative;
+  z-index: 5;
+  min-height: 100vh;
+  padding: clamp(2.5rem, 6vw, 4.75rem) clamp(1.5rem, 5vw, 3.5rem);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(2rem, 5vw, 3.5rem);
+  background: linear-gradient(160deg, rgba(56, 189, 248, 0.12), rgba(56, 189, 248, 0));
+  width: min(100%, 70rem);
+  margin: 0 auto;
 }
 
 .projects-title {
@@ -29,10 +31,13 @@
 }
 
 .project-cards {
-    width: min(80vw, 1120px);
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: clamp(1.5rem, 3vw, 2.5rem);
+  width: 100%;
+  max-width: 68rem;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+  padding-inline: clamp(0.75rem, 4vw, 2rem);
 }
 
 .project-card {
@@ -227,15 +232,15 @@
 }
 
 @media (max-width: 1200px) {
-    .project-cards {
-        width: min(86vw, 960px);
-    }
+  .project-cards {
+    padding-inline: clamp(0.5rem, 4vw, 1.5rem);
+  }
 }
 
 @media (max-width: 900px) {
-    .project-cards {
-        width: min(90vw, 820px);
-    }
+  .project-cards {
+    padding-inline: clamp(0.5rem, 5vw, 1.25rem);
+  }
 }
 
 @media (max-width: 768px) {

--- a/src/app/components/projects/projects.component.ts
+++ b/src/app/components/projects/projects.component.ts
@@ -154,11 +154,13 @@ export class ProjectsComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   getStatusLevelLabel(level: ProjectStatusLevel): string {
-    return this.projects.statusLegend.levels[level] ?? level;
+    const label = this.projects.statusLegend.levels[level];
+    return label?.trim() ? label : level;
   }
 
   getStatusTagLabel(tag: ProjectStatusTag): string {
-    return this.projects.statusLegend.tags[tag] ?? tag;
+    const label = this.projects.statusLegend.tags[tag];
+    return label?.trim() ? label : tag;
   }
 
   private triggerPeekAnimation(): void {

--- a/src/app/components/skills/skills.component.scss
+++ b/src/app/components/skills/skills.component.scss
@@ -26,7 +26,7 @@
   align-items: center;
   gap: clamp(1.75rem, 4vw, 3rem);
   background: var(--skills-section-bg);
-  width: min(95vw, 100%);
+  width: min(100%, 70rem);
   margin-inline: auto;
 }
 
@@ -39,16 +39,21 @@
 
 .mobile-layout,
 .carousel-container {
-  width: min(96vw, 540px);
+  width: min(100%, 540px);
   margin: 0 auto;
+  padding-inline: clamp(0.75rem, 5vw, 1.5rem);
+  box-sizing: border-box;
 }
 
 .skills-grid {
   width: 100%;
+  max-width: 68rem;
   display: grid;
   grid-template-columns: minmax(200px, 260px) 1fr;
   gap: clamp(1.5rem, 3vw, 2.75rem);
   align-items: start;
+  padding-inline: clamp(0.75rem, 4vw, 2rem);
+  margin: 0 auto;
 }
 
 .stack-tabs {
@@ -249,7 +254,7 @@
 
 @media (min-width: 992px) {
   .skills-section {
-    max-width: 80vw;
+    max-width: 70rem;
   }
 
   .spotlight-panels {

--- a/src/app/components/skills/skills.component.scss
+++ b/src/app/components/skills/skills.component.scss
@@ -6,6 +6,9 @@
   --skills-text-muted: rgba(15, 23, 42, 0.65);
   --skills-section-bg: linear-gradient(160deg, rgba(99, 102, 241, 0.1), rgba(59, 130, 246, 0.04));
   --skills-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
+  display: block;
+  inline-size: 100%;
+  block-size: 100%;
 }
 
 :host-context(body.dark-mode) {
@@ -19,7 +22,9 @@
 }
 
 .skills-section {
-  min-height: 100vh;
+  inline-size: 100%;
+  block-size: 100%;
+  min-block-size: 100%;
   padding: clamp(2rem, 4vw, 4.5rem) clamp(1.5rem, 4vw, 3.5rem);
   display: flex;
   flex-direction: column;
@@ -28,6 +33,7 @@
   background: var(--skills-section-bg);
   width: min(100%, 70rem);
   margin-inline: auto;
+  overflow: auto;
 }
 
 .skills-title {

--- a/src/app/components/stats/stats.component.scss
+++ b/src/app/components/stats/stats.component.scss
@@ -1,3 +1,8 @@
+:host {
+    display: block;
+    inline-size: 100%;
+    block-size: 100%;
+}
 
 .statistics-component {
     --stat-bg: linear-gradient(160deg, rgba(99, 102, 241, 0.12), rgba(79, 70, 229, 0.05));
@@ -10,7 +15,9 @@
     --stat-title-color: #0f172a;
     --stat-hover-shadow: 0 26px 60px -28px rgba(79, 70, 229, 0.4);
 
-    min-height: 100vh;
+    inline-size: 100%;
+    block-size: 100%;
+    min-block-size: 100%;
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -19,6 +26,7 @@
     position: relative;
     background: var(--stat-bg);
     isolation: isolate;
+    overflow: auto;
 
     &::before {
         content: '';

--- a/src/app/components/stats/stats.component.scss
+++ b/src/app/components/stats/stats.component.scss
@@ -15,7 +15,7 @@
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    padding: 6rem 1.5rem;
+    padding: clamp(3rem, 8vh, 6rem) clamp(1rem, 5vw, 3rem);
     position: relative;
     background: var(--stat-bg);
     isolation: isolate;
@@ -33,11 +33,12 @@
     .statistics-section {
         position: relative;
         width: 100%;
-        max-width: 1320px;
+        max-width: 70rem;
+        margin: 0 auto;
 
         .statistics-container {
             margin: 0 auto;
-            padding: 0 1.5rem;
+            padding: 0 clamp(1rem, 4vw, 2.5rem);
         }
 
         .statistics-row {
@@ -45,6 +46,7 @@
             flex-wrap: wrap;
             gap: 24px;
             justify-content: center;
+            width: 100%;
         }
 
         .statistics-card {
@@ -127,7 +129,7 @@
     }
 
     @media (max-width: 992px) {
-        padding: 4rem 1rem;
+        padding: clamp(2.5rem, 8vw, 4rem) clamp(0.75rem, 5vw, 2rem);
 
         .statistics-section {
             .statistics-card {
@@ -139,7 +141,7 @@
     }
 
     @media (max-width: 768px) {
-        padding: 3rem 1rem;
+        padding: clamp(2.25rem, 9vw, 3rem) clamp(0.75rem, 6vw, 1.75rem);
 
         .statistics-section {
             .statistics-card {
@@ -156,11 +158,11 @@
     }
 
     @media (max-width: 480px) {
-        padding: 2.5rem 0.75rem;
+        padding: clamp(2rem, 10vw, 2.75rem) clamp(0.5rem, 6vw, 1.25rem);
 
         .statistics-section {
             .statistics-container {
-                padding: 0 1rem;
+                padding: 0 clamp(0.75rem, 6vw, 1.25rem);
             }
 
             .statistics-card {

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -1,42 +1,58 @@
 <div *ngIf="viewInitialized" class="home">
   <section #section class="home__section">
     <div class="home__section-content">
-      <app-hero (navigateNextSection)="navigateNext()"></app-hero>
+      <div class="home__panel">
+        <app-hero (navigateNextSection)="navigateNext()"></app-hero>
+      </div>
     </div>
   </section>
   <section #section class="home__section">
     <div class="home__section-content">
-      <app-about></app-about>
+      <div class="home__panel">
+        <app-about></app-about>
+      </div>
     </div>
   </section>
   <section #section class="home__section">
     <div class="home__section-content">
-      <app-projects></app-projects>
+      <div class="home__panel">
+        <app-projects></app-projects>
+      </div>
     </div>
   </section>
   <section #section class="home__section">
     <div class="home__section-content">
-      <app-skills></app-skills>
-    </div>
-  </section>
-  <section #section class="home__section home__section--tall">
-    <div class="home__section-content">
-      <app-education></app-education>
-    </div>
-  </section>
-  <section #section class="home__section home__section--tall">
-    <div class="home__section-content">
-      <app-experiences></app-experiences>
+      <div class="home__panel">
+        <app-skills></app-skills>
+      </div>
     </div>
   </section>
   <section #section class="home__section">
     <div class="home__section-content">
-      <app-stats></app-stats>
+      <div class="home__panel">
+        <app-education></app-education>
+      </div>
     </div>
   </section>
   <section #section class="home__section">
     <div class="home__section-content">
-      <app-contact-me></app-contact-me>
+      <div class="home__panel">
+        <app-experiences></app-experiences>
+      </div>
+    </div>
+  </section>
+  <section #section class="home__section">
+    <div class="home__section-content">
+      <div class="home__panel">
+        <app-stats></app-stats>
+      </div>
+    </div>
+  </section>
+  <section #section class="home__section">
+    <div class="home__section-content">
+      <div class="home__panel">
+        <app-contact-me></app-contact-me>
+      </div>
     </div>
   </section>
 

--- a/src/app/pages/home/home.component.scss
+++ b/src/app/pages/home/home.component.scss
@@ -17,7 +17,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: clamp(1.5rem, 4vh, 3rem) 0;
+  padding: clamp(1.5rem, 4vh, 3rem) clamp(1.25rem, 5vw, 3.5rem);
   margin: 0;
   box-shadow: none;
   border-radius: 0;
@@ -31,8 +31,8 @@
     position: absolute;
     left: 50%;
     transform: translateX(-50%);
-    width: min(82rem, calc(100% - clamp(3rem, 10vw, 8rem)));
-    max-width: 1200px;
+    width: min(80rem, calc(100% - clamp(2.5rem, 8vw, 6rem)));
+    max-width: min(80rem, 100%);
     height: clamp(54px, 12vh, 140px);
     pointer-events: none;
     z-index: 0;
@@ -61,6 +61,8 @@
 .home__section-content {
   position: relative;
   width: 100%;
+  max-width: clamp(18rem, 92vw, 70rem);
+  margin: 0 auto;
   min-height: 100%;
   display: flex;
   flex-direction: column;
@@ -68,6 +70,8 @@
   align-items: stretch;
   gap: clamp(1rem, 3vh, 2rem);
   z-index: 1;
+  padding-inline: clamp(0.75rem, 4vw, 2.75rem);
+  box-sizing: border-box;
 }
 
 .home__section--tall {
@@ -105,13 +109,14 @@
 
 @media (max-width: 768px) {
   .home__section {
-    padding: clamp(1.25rem, 5vh, 2.5rem) 0;
+    padding: clamp(1.25rem, 5vh, 2.5rem) clamp(1rem, 6vw, 2.5rem);
   }
 
   .home__section-content {
     width: 100%;
     min-height: 100%;
     gap: clamp(0.75rem, 3vh, 1.5rem);
+    padding-inline: clamp(0.75rem, 6vw, 2rem);
   }
 
   .home__section--tall {

--- a/src/app/pages/home/home.component.scss
+++ b/src/app/pages/home/home.component.scss
@@ -4,26 +4,28 @@
 
 .home {
   position: relative;
-  width: 100%;
-  min-height: 100vh;
-  min-height: 100dvh;
+  inline-size: 100vw;
+  min-block-size: 100vh;
+  min-block-size: 100dvh;
+  overflow-x: hidden;
 }
 
 .home__section {
   position: relative;
-  width: 100%;
-  min-height: 100vh;
-  min-height: 100dvh;
+  inline-size: 100%;
+  block-size: 100vh;
+  block-size: 100dvh;
   display: flex;
-  align-items: center;
+  align-items: stretch;
   justify-content: center;
-  padding: clamp(1.5rem, 4vh, 3rem) clamp(1.25rem, 5vw, 3.5rem);
+  padding: 0;
   margin: 0;
   box-shadow: none;
   border-radius: 0;
   scroll-snap-align: start;
   scroll-snap-stop: always;
   isolation: isolate;
+  overflow: hidden;
 
   &::before,
   &::after {
@@ -31,12 +33,16 @@
     position: absolute;
     left: 50%;
     transform: translateX(-50%);
-    width: min(80rem, calc(100% - clamp(2.5rem, 8vw, 6rem)));
-    max-width: min(80rem, 100%);
-    height: clamp(54px, 12vh, 140px);
+    inline-size: min(80rem, calc(100% - clamp(2.5rem, 8vw, 6rem)));
+    max-inline-size: min(80rem, 100%);
+    block-size: clamp(54px, 12vh, 140px);
     pointer-events: none;
     z-index: 0;
-    background: radial-gradient(ellipse at center, var(--section-transition-glow, rgba(148, 163, 184, 0.18)) 0%, rgba(148, 163, 184, 0) 70%);
+    background: radial-gradient(
+      ellipse at center,
+      var(--section-transition-glow, rgba(148, 163, 184, 0.18)) 0%,
+      rgba(148, 163, 184, 0) 70%
+    );
     opacity: 0.65;
     filter: blur(32px);
     transition: opacity 0.4s ease;
@@ -60,29 +66,38 @@
 
 .home__section-content {
   position: relative;
-  width: 100%;
-  max-width: clamp(18rem, 92vw, 70rem);
+  inline-size: 100%;
+  block-size: 100%;
+  max-inline-size: 100%;
   margin: 0 auto;
-  min-height: 100%;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: stretch;
   gap: clamp(1rem, 3vh, 2rem);
   z-index: 1;
-  padding-inline: clamp(0.75rem, 4vw, 2.75rem);
+  padding: clamp(1.5rem, 4vh, 3rem) clamp(1.25rem, 5vw, 3.5rem);
   box-sizing: border-box;
 }
 
-.home__section--tall {
-  min-height: max(120vh, 960px);
-  min-height: max(120dvh, 960px);
-  padding-bottom: clamp(3rem, 8vh, 6rem);
+.home__panel {
+  flex: 1 1 auto;
+  inline-size: 100%;
+  block-size: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: stretch;
+  overflow: hidden;
+  padding-inline: clamp(0.75rem, 4vw, 2.75rem);
+  margin: 0 auto;
+  max-inline-size: 100%;
+  box-sizing: border-box;
 }
 
-.home__section-content > * {
+.home__panel > * {
+  inline-size: 100%;
   flex: 1 1 auto;
-  width: 100%;
 }
 
 .home__floating-controls {
@@ -108,20 +123,13 @@
 }
 
 @media (max-width: 768px) {
-  .home__section {
+  .home__section-content {
+    gap: clamp(0.75rem, 3vh, 1.5rem);
     padding: clamp(1.25rem, 5vh, 2.5rem) clamp(1rem, 6vw, 2.5rem);
   }
 
-  .home__section-content {
-    width: 100%;
-    min-height: 100%;
-    gap: clamp(0.75rem, 3vh, 1.5rem);
+  .home__panel {
     padding-inline: clamp(0.75rem, 6vw, 2rem);
-  }
-
-  .home__section--tall {
-    min-height: max(120vh, 820px);
-    min-height: max(120dvh, 820px);
   }
 
   .home__floating-controls {

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -8,6 +8,22 @@
 @use 'responsiveness/pc';
 @use 'responsiveness/large';
 
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
+img,
+picture,
+video,
+canvas,
+svg {
+    display: block;
+    max-width: 100%;
+    height: auto;
+}
+
 :root {
     --assistant-avatar-size-sm: 48px;
 }
@@ -24,6 +40,7 @@ body {
     max-width: 100vw;
     overflow-x: hidden;
     --section-transition-glow: rgba(148, 163, 184, 0.18);
+    background-color: inherit;
 }
 
 body.home-scroll-snapping {


### PR DESCRIPTION
## Summary
- add a global box-sizing reset and responsive media defaults to stabilize layout measurements
- adjust the home shell padding and content container so sections stay centered without overflowing
- align projects, skills, timeline, statistics, and contact sections with consistent max-width, padding, and mobile-friendly tweaks

## Testing
- `npm run build` *(fails: Angular CLI binaries unavailable because dependencies could not be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e57626d364832b9720214ac8c28a3d