### PR TITLE
Fix section padding and margins

### DIFF
--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -75,14 +75,14 @@ button {
 }
 
 section {
-    padding: 0 1.5em 3em 1.5em;
+    inline-size: 100%;
+    margin: 0;
+    padding: 0;
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
     text-align: center;
-    margin-top: 1vh;
-    margin-bottom: 1vh;
 }
 
 .social-container {


### PR DESCRIPTION
## Summary
- remove the default padding and margins from the global section styles so background fills the viewport
- ensure sections span the full width by setting inline size to 100%

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e61db1b7fc832babed98f48a2f090b