### PR TITLE
Fix overflow of education and experience sections

### DIFF
--- a/src/app/components/education/education.component.scss
+++ b/src/app/components/education/education.component.scss
@@ -29,7 +29,7 @@
 
 .education-section {
   inline-size: 100%;
-  block-size: 100%;
+  block-size: auto;
   min-block-size: 100%;
   box-sizing: border-box;
   padding: clamp(2rem, 4vw, 4.5rem) clamp(1.5rem, 5vw, 3.5rem);
@@ -38,7 +38,7 @@
   align-items: center;
   background: var(--timeline-section-bg);
   width: 100%;
-  overflow: auto;
+  overflow: visible;
 }
 
 .education-content {

--- a/src/app/components/experiences/experiences.component.scss
+++ b/src/app/components/experiences/experiences.component.scss
@@ -29,7 +29,7 @@
 
 .experiences-section {
   inline-size: 100%;
-  block-size: 100%;
+  block-size: auto;
   min-block-size: 100%;
   box-sizing: border-box;
   padding: clamp(2rem, 4vw, 4.5rem) clamp(1.5rem, 5vw, 3.5rem);
@@ -38,7 +38,7 @@
   align-items: center;
   background: var(--timeline-section-bg);
   width: 100%;
-  overflow: auto;
+  overflow: visible;
 }
 
 .experiences-content {

--- a/src/app/pages/home/home.component.scss
+++ b/src/app/pages/home/home.component.scss
@@ -13,8 +13,9 @@
 .home__section {
   position: relative;
   inline-size: 100%;
-  block-size: 100vh;
-  block-size: 100dvh;
+  block-size: auto;
+  min-block-size: 100vh;
+  min-block-size: 100dvh;
   display: flex;
   align-items: stretch;
   justify-content: center;
@@ -25,7 +26,7 @@
   scroll-snap-align: start;
   scroll-snap-stop: always;
   isolation: isolate;
-  overflow: hidden;
+  overflow: visible;
 
   &::before,
   &::after {
@@ -83,13 +84,14 @@
 .home__panel {
   flex: 1 1 auto;
   inline-size: 100%;
-  block-size: 100%;
+  block-size: auto;
+  min-block-size: 100%;
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
   align-items: stretch;
-  overflow: hidden;
-  overflow-y: auto;
+  overflow-x: hidden;
+  overflow-y: visible;
   padding: 0;
   margin: 0 auto;
   max-inline-size: 100%;


### PR DESCRIPTION
## Summary
- allow home panels to scroll vertically so tall sections keep their titles in view
- stop forcing all embedded components to stretch, while maintaining full-height layout for compact sections

## Testing
- not run (npm install failed: npm error 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68e6607d3ae4832ba8e4ba2c032bb976