### PR TITLE
Center mobile projects carousel and card interactions

### DIFF
--- a/src/app/components/projects/projects.carousel.component.scss
+++ b/src/app/components/projects/projects.carousel.component.scss
@@ -1,6 +1,7 @@
 // Carosello per dispositivi mobili
 .carousel-container {
-    width: min(100%, 420px);
+    width: 100%;
+    max-width: 480px;
     margin: 0 auto;
     display: flex;
     flex-direction: column;
@@ -10,6 +11,8 @@
 }
 
 .carousel-viewport {
+    display: flex;
+    width: 100%;
     overflow-x: auto;
     overflow-y: visible;
     scroll-snap-type: x mandatory;
@@ -17,6 +20,7 @@
     scrollbar-width: none;
     mask-image: linear-gradient(90deg, transparent 0, rgba(0, 0, 0, 0.35) 16px, rgba(0, 0, 0, 1) 56px, rgba(0, 0, 0, 1) calc(100% - 56px), rgba(0, 0, 0, 0.35) calc(100% - 16px), transparent 100%);
     padding-block: 0.25rem;
+    scroll-padding-inline: clamp(1rem, 7vw, 2rem);
 
     &::-webkit-scrollbar {
         display: none;
@@ -24,16 +28,20 @@
 }
 
 .carousel-wrapper {
-    display: flex;
-    gap: 1.15rem;
-    padding-inline: clamp(0.25rem, 3vw, 0.75rem) clamp(0.75rem, 6vw, 1.5rem);
+    display: grid;
+    grid-auto-flow: column;
+    grid-auto-columns: 100%;
+    gap: clamp(0.75rem, 4vw, 1.25rem);
+    padding-inline: clamp(1rem, 6vw, 2rem);
+    width: 100%;
     transition: transform 0.6s ease;
 }
 
 .carousel-item {
-    flex: 0 0 calc(100% - 3.5rem);
-    scroll-snap-align: start;
+    scroll-snap-align: center;
     scroll-snap-stop: always;
+    display: flex;
+    justify-content: center;
 }
 
 .carousel-container.is-peeking .carousel-wrapper {

--- a/src/app/components/projects/projects.component.html
+++ b/src/app/components/projects/projects.component.html
@@ -23,7 +23,8 @@
     </div>
 
     <ng-template #projectCard let-project let-i="index">
-        <article class="project-card" [attr.data-status-level]="project.status.level">
+        <a class="project-card" [attr.data-status-level]="project.status.level" [href]="project.link"
+            target="_blank" rel="noopener noreferrer">
             <div class="project-visual">
                 <img class="proj-image" [src]="project.image" [attr.alt]="'Anteprima del progetto ' + project.title" />
             </div>
@@ -53,8 +54,6 @@
                     <p>{{ project.description }}</p>
                 </div>
             </div>
-
-            <a class="proj-link" [href]="project.link" target="_blank">{{ projects.button }}</a>
-        </article>
+        </a>
     </ng-template>
 </section>

--- a/src/app/components/projects/projects.component.scss
+++ b/src/app/components/projects/projects.component.scss
@@ -58,11 +58,19 @@
     box-shadow: var(--projects-card-shadow);
     backdrop-filter: blur(12px);
     transition: transform 0.4s ease, box-shadow 0.4s ease, border-color 0.4s ease;
+    text-decoration: none;
+    color: inherit;
+    cursor: pointer;
 
     &:hover {
         transform: translateY(-6px);
         box-shadow: 0 28px 60px rgba(15, 23, 42, 0.18);
         border-color: rgba(56, 189, 248, 0.45);
+    }
+
+    &:focus-visible {
+        outline: 3px solid rgba(14, 165, 233, 0.55);
+        outline-offset: 4px;
     }
 }
 
@@ -214,29 +222,6 @@
     display: none;
 }
 
-.proj-link {
-    margin-top: auto;
-    align-self: flex-start;
-    padding: 0.55rem 1.15rem;
-    border-radius: 999px;
-    background: rgba(56, 189, 248, 0.85);
-    color: #0f172a;
-    font-weight: 700;
-    text-decoration: none;
-    letter-spacing: 0.01em;
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
-
-    &:hover {
-        transform: translateY(-2px);
-        box-shadow: 0 18px 36px rgba(56, 189, 248, 0.28);
-    }
-
-    &:focus-visible {
-        outline: 2px solid rgba(14, 165, 233, 0.9);
-        outline-offset: 3px;
-    }
-}
-
 @media (max-width: 1200px) {
   .project-cards {
     padding-inline: clamp(0.5rem, 4vw, 1.5rem);
@@ -256,5 +241,7 @@
 
     .project-card {
         padding: clamp(1.4rem, 6vw, 1.75rem);
+        width: min(100%, 360px);
+        margin-inline: auto;
     }
 }


### PR DESCRIPTION
## Summary
- make each project card act as the clickable link so the desktop button is no longer needed
- tweak mobile carousel layout to center a single project card in view while keeping the peek animation
- update shared project card styles for pointer, focus, and mobile sizing behaviour

## Testing
- npm install *(fails: 403 Forbidden - GET https://registry.npmjs.org/@angular%2fcompiler-cli)*

------
https://chatgpt.com/codex/tasks/task_e_68e6612f2754832b9d8f2532526131d7