### PR TITLE
Restore responsive key numbers grid

### DIFF
--- a/src/app/components/stats/stats.component.html
+++ b/src/app/components/stats/stats.component.html
@@ -1,26 +1,23 @@
-<section class="stats-section" *ngIf="!isLoading">
-  <h2 class="stats-title">{{ statsTitle }}</h2>
-  <div class="stats-timeline" role="list">
-    <article
-      class="stats-item"
-      role="listitem"
-      *ngFor="let stat of statistics; let last = last"
-    >
-      <div class="stats-marker" [class.is-last]="last">
-        <span class="stats-dot" aria-hidden="true"></span>
-      </div>
-      <div class="stats-card">
-        <header class="stats-header">
-          <div class="stats-icon" aria-hidden="true">
-            <mat-icon>{{ stat.icon }}</mat-icon>
+<section class="statistics-component" *ngIf="!isLoading">
+  <div class="statistics-section">
+    <h2 class="statistics-section-title">{{ statsTitle }}</h2>
+    <div class="statistics-container">
+      <div class="statistics-row" role="list">
+        <article
+          class="statistics-card"
+          role="listitem"
+          *ngFor="let stat of statistics"
+        >
+          <div class="statistics-content">
+            <div class="statistics-icon" aria-hidden="true">
+              <mat-icon>{{ stat.icon }}</mat-icon>
+            </div>
+            <p class="statistics-value">{{ stat.value }}</p>
+            <p class="statistics-label">{{ stat.label }}</p>
+            <p class="statistics-suffix" *ngIf="stat.suffix">{{ stat.suffix }}</p>
           </div>
-          <p class="stats-label">{{ stat.label }}</p>
-        </header>
-        <div class="stats-value-group">
-          <span class="stats-value">{{ stat.value }}</span>
-          <span class="stats-suffix" *ngIf="stat.suffix">{{ stat.suffix }}</span>
-        </div>
+        </article>
       </div>
-    </article>
+    </div>
   </div>
 </section>

--- a/src/app/components/stats/stats.component.scss
+++ b/src/app/components/stats/stats.component.scss
@@ -114,6 +114,13 @@
                     max-width: 100%;
                     margin: 0;
                 }
+
+                .statistics-suffix {
+                    font-size: 0.95rem;
+                    color: rgba(15, 23, 42, 0.5);
+                    margin: 0;
+                    text-wrap: balance;
+                }
             }
         }
 
@@ -124,6 +131,7 @@
             text-align: center;
             margin-bottom: 3rem;
             color: var(--stat-title-color);
+            text-wrap: balance;
         }
     }
 


### PR DESCRIPTION
## Summary
- reintroduce the card-based markup for the key numbers section so it matches the previous grid layout
- tune the accompanying styles for suffix text and headings to align with the current UI while remaining responsive

## Testing
- npm run test:headless *(fails: /bin/sh: 1: Syntax error: "(" unexpected (expecting ")"))*
- bash -lc 'CHROME_PATH=$(node -p "require("puppeteer").executablePath()"); export CHROME_BIN="$CHROME_PATH"; npx ng test --watch=false --browsers=ChromeHeadlessPuppeteer' *(fails: Cannot find module 'puppeteer' and npm 403 when fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e661d99160832b8bb1e4fb9e5e718e