### PR TITLE
Adjust home layout to limit hero sizing

### DIFF
--- a/src/app/components/education/education.component.scss
+++ b/src/app/components/education/education.component.scss
@@ -29,15 +29,16 @@
 
 .education-section {
   inline-size: 100%;
-  block-size: 100%;
+  block-size: auto;
   min-block-size: 100%;
+  box-sizing: border-box;
   padding: clamp(2rem, 4vw, 4.5rem) clamp(1.5rem, 5vw, 3.5rem);
   display: flex;
   flex-direction: column;
   align-items: center;
   background: var(--timeline-section-bg);
   width: 100%;
-  overflow: auto;
+  overflow: visible;
 }
 
 .education-content {

--- a/src/app/components/experiences/experiences.component.scss
+++ b/src/app/components/experiences/experiences.component.scss
@@ -29,15 +29,16 @@
 
 .experiences-section {
   inline-size: 100%;
-  block-size: 100%;
+  block-size: auto;
   min-block-size: 100%;
+  box-sizing: border-box;
   padding: clamp(2rem, 4vw, 4.5rem) clamp(1.5rem, 5vw, 3.5rem);
   display: flex;
   flex-direction: column;
   align-items: center;
   background: var(--timeline-section-bg);
   width: 100%;
-  overflow: auto;
+  overflow: visible;
 }
 
 .experiences-content {

--- a/src/app/components/hero/hero.component.scss
+++ b/src/app/components/hero/hero.component.scss
@@ -16,6 +16,8 @@ h1 {
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  inline-size: 100%;
+  max-inline-size: 100vw;
   block-size: 100%;
   min-block-size: 100%;
   text-align: center;
@@ -23,7 +25,7 @@ h1 {
 }
 
 .bottom-border {
-  width: 100vw;
+  width: 100%;
   height: 7px;
   position: absolute;
   bottom: 0;

--- a/src/app/pages/home/home.component.scss
+++ b/src/app/pages/home/home.component.scss
@@ -4,7 +4,7 @@
 
 .home {
   position: relative;
-  inline-size: 100vw;
+  inline-size: 100%;
   min-block-size: 100vh;
   min-block-size: 100dvh;
   overflow-x: hidden;
@@ -13,8 +13,7 @@
 .home__section {
   position: relative;
   inline-size: 100%;
-  block-size: 100vh;
-  block-size: 100dvh;
+  block-size: auto;
   display: flex;
   align-items: stretch;
   justify-content: center;
@@ -25,7 +24,7 @@
   scroll-snap-align: start;
   scroll-snap-stop: always;
   isolation: isolate;
-  overflow: hidden;
+  overflow: visible;
 
   &::before,
   &::after {
@@ -67,7 +66,7 @@
 .home__section-content {
   position: relative;
   inline-size: 100%;
-  block-size: 100%;
+  block-size: auto;
   max-inline-size: 100%;
   margin: 0 auto;
   display: flex;
@@ -83,12 +82,13 @@
 .home__panel {
   flex: 1 1 auto;
   inline-size: 100%;
-  block-size: 100%;
+  block-size: auto;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: stretch;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: visible;
   padding: 0;
   margin: 0 auto;
   max-inline-size: 100%;
@@ -97,7 +97,25 @@
 
 .home__panel > * {
   inline-size: 100%;
-  flex: 1 1 auto;
+  flex: 0 0 auto;
+}
+
+.home__panel > app-hero,
+.home__panel > app-about,
+.home__panel > app-projects,
+.home__panel > app-skills,
+.home__panel > app-stats,
+.home__panel > app-contact-me {
+  flex: 1 0 auto;
+}
+
+.home__section:first-of-type {
+  min-block-size: 100vh;
+  min-block-size: 100dvh;
+}
+
+.home__section:first-of-type .home__panel {
+  min-block-size: 100%;
 }
 
 .home__floating-controls {


### PR DESCRIPTION
## Summary
- limit the full-viewport height rule to the first home section so other panels can grow with their content
- keep the hero panel constrained to the screen width by using percentage sizing for its container elements

## Testing
- `npm install --no-audit --progress=false` *(fails with 403 Forbidden when downloading @angular/compiler-cli)*

------
https://chatgpt.com/codex/tasks/task_e_68e6607d3ae4832ba8e4ba2c032bb976