### PR TITLE
Revamp statistics section styling

### DIFF
--- a/src/app/components/stats/stats.component.scss
+++ b/src/app/components/stats/stats.component.scss
@@ -1,194 +1,198 @@
 :host {
     display: block;
     inline-size: 100%;
-    block-size: 100%;
 }
 
 .statistics-component {
-    --stat-bg: linear-gradient(160deg, rgba(99, 102, 241, 0.12), rgba(79, 70, 229, 0.05));
-    --stat-card-bg: rgba(255, 255, 255, 0.92);
-    --stat-card-border: rgba(99, 102, 241, 0.22);
-    --stat-icon-bg: rgba(99, 102, 241, 0.12);
-    --stat-icon-color: #6366f1;
-    --stat-label-color: rgba(15, 23, 42, 0.65);
-    --stat-value-color: #0f172a;
-    --stat-title-color: #0f172a;
-    --stat-hover-shadow: 0 26px 60px -28px rgba(79, 70, 229, 0.4);
+    --stat-bg: linear-gradient(160deg, rgba(55, 65, 81, 0.12), rgba(99, 102, 241, 0.22));
+    --stat-card-bg: rgba(15, 23, 42, 0.82);
+    --stat-card-border: rgba(148, 163, 184, 0.25);
+    --stat-icon-bg: rgba(99, 102, 241, 0.16);
+    --stat-icon-color: #eef2ff;
+    --stat-label-color: rgba(226, 232, 240, 0.72);
+    --stat-value-color: #f8fafc;
+    --stat-title-color: #f8fafc;
+    --stat-hover-shadow: 0 30px 60px -24px rgba(30, 64, 175, 0.55);
 
     inline-size: 100%;
-    block-size: 100vh;
-    min-block-size: 100%;
+    min-block-size: 100vh;
     display: flex;
-    flex-direction: column;
-    justify-content: center;
     align-items: center;
-    padding: clamp(3rem, 8vh, 6rem) clamp(1rem, 5vw, 3rem);
+    justify-content: center;
+    padding: clamp(3rem, 8vh, 6rem) clamp(1.25rem, 6vw, 3.5rem);
     position: relative;
     background: var(--stat-bg);
     isolation: isolate;
-    overflow: auto;
+    overflow: hidden;
 
-    &::before {
+    @supports (min-height: 100dvh) {
+        min-block-size: 100dvh;
+    }
+
+    &::before,
+    &::after {
         content: '';
         position: absolute;
-        inset: 0;
-        background: inherit;
-        filter: blur(80px);
-        opacity: 0.55;
-        z-index: -1;
+        border-radius: 999px;
+        filter: blur(100px);
+        opacity: 0.6;
+        z-index: -2;
+    }
+
+    &::before {
+        inline-size: clamp(22rem, 45vw, 28rem);
+        block-size: clamp(22rem, 40vh, 28rem);
+        inset-block-start: -15%;
+        inset-inline-start: -20%;
+        background: radial-gradient(circle at center, rgba(99, 102, 241, 0.7), transparent 65%);
+    }
+
+    &::after {
+        inline-size: clamp(18rem, 40vw, 24rem);
+        block-size: clamp(18rem, 35vh, 24rem);
+        inset-block-end: -18%;
+        inset-inline-end: -10%;
+        background: radial-gradient(circle at center, rgba(14, 165, 233, 0.55), transparent 70%);
     }
 
     .statistics-section {
         position: relative;
-        width: 100%;
-        max-width: 70rem;
-        margin: 0 auto;
+        inline-size: min(100%, 68rem);
+        margin-inline: auto;
+        padding-inline: clamp(0rem, 2vw, 1.5rem);
+        color: var(--stat-value-color);
+
+        .statistics-section-title,
+        h1 {
+            font-size: clamp(1.8rem, 4vw, 2.8rem);
+            font-weight: 700;
+            text-align: center;
+            margin: 0 0 clamp(2rem, 5vh, 3.5rem);
+            color: var(--stat-title-color);
+            text-wrap: balance;
+            letter-spacing: -0.02em;
+        }
 
         .statistics-container {
             margin: 0 auto;
-            padding: 0 clamp(1rem, 4vw, 2.5rem);
         }
 
         .statistics-row {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 24px;
-            justify-content: center;
-            width: 100%;
+            display: grid;
+            gap: clamp(1.5rem, 4vw, 2.75rem);
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
         }
 
         .statistics-card {
             background: var(--stat-card-bg);
             border: 1px solid var(--stat-card-border);
-            border-radius: 20px;
-            padding: 32px 28px;
-            text-align: center;
-            flex: 1 1 calc(25% - 24px);
-            min-width: 250px;
-            max-width: 320px;
-            transition: transform 0.3s ease, box-shadow 0.3s ease;
-            box-shadow: 0 22px 45px -28px rgba(79, 70, 229, 0.35);
-            backdrop-filter: blur(12px);
+            border-radius: 26px;
+            padding: clamp(1.75rem, 5vw, 2.75rem);
+            position: relative;
+            overflow: hidden;
+            isolation: isolate;
+            box-shadow: 0 20px 45px -28px rgba(15, 23, 42, 0.6);
+            backdrop-filter: blur(14px);
+            transition: transform 0.35s ease, box-shadow 0.35s ease, border-color 0.35s ease;
+            height: 100%;
+
+            &::after {
+                content: '';
+                position: absolute;
+                inset: 12% auto auto 12%;
+                inline-size: 60%;
+                block-size: 60%;
+                background: radial-gradient(circle at top left, rgba(99, 102, 241, 0.25), transparent 70%);
+                z-index: -1;
+                opacity: 0;
+                transition: opacity 0.35s ease;
+            }
 
             &:hover {
-                transform: translateY(-12px);
-                cursor: pointer;
+                transform: translateY(-10px);
+                border-color: rgba(99, 102, 241, 0.45);
                 box-shadow: var(--stat-hover-shadow);
+
+                &::after {
+                    opacity: 1;
+                }
             }
 
             .statistics-content {
-                width: 100%;
+                inline-size: 100%;
                 display: flex;
                 flex-direction: column;
                 align-items: center;
-                gap: 0.75rem;
+                gap: clamp(0.65rem, 1.5vw, 1.1rem);
+                text-align: center;
 
                 .statistics-icon {
                     display: inline-flex;
                     align-items: center;
                     justify-content: center;
-                    width: 68px;
-                    height: 68px;
-                    border-radius: 20px;
+                    inline-size: clamp(72px, 10vw, 88px);
+                    block-size: clamp(72px, 10vw, 88px);
+                    border-radius: 22px;
                     background: var(--stat-icon-bg);
                     color: var(--stat-icon-color);
-                    margin-bottom: 0.5rem;
+                    margin-block-end: clamp(0.35rem, 1vw, 0.75rem);
+                    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.35);
 
                     mat-icon {
-                        font-size: 3rem;
-                        width: 1em;
-                        height: 1em;
+                        font-size: clamp(2.75rem, 6vw, 3.5rem);
+                        inline-size: 1em;
+                        block-size: 1em;
                     }
                 }
 
                 .statistics-value {
-                    font-size: 2.15rem;
+                    font-size: clamp(2rem, 6vw, 2.8rem);
                     font-weight: 700;
                     color: var(--stat-value-color);
                     margin: 0;
+                    letter-spacing: -0.015em;
                 }
 
                 .statistics-label {
-                    font-size: 1.15rem;
+                    font-size: clamp(0.9rem, 2.6vw, 1.05rem);
+                    text-transform: uppercase;
+                    letter-spacing: 0.2em;
                     color: var(--stat-label-color);
-                    max-width: 100%;
                     margin: 0;
                 }
 
                 .statistics-suffix {
-                    font-size: 0.95rem;
-                    color: rgba(15, 23, 42, 0.5);
+                    font-size: clamp(0.8rem, 2.4vw, 0.95rem);
+                    color: rgba(226, 232, 240, 0.6);
                     margin: 0;
                     text-wrap: balance;
                 }
             }
         }
-
-        .statistics-section-title,
-        h1 {
-            font-size: 2.75rem;
-            font-weight: 600;
-            text-align: center;
-            margin-bottom: 3rem;
-            color: var(--stat-title-color);
-            text-wrap: balance;
-        }
-    }
-
-    @media (max-width: 1200px) {
-        .statistics-section {
-            .statistics-card {
-                flex: 1 1 calc(33.33% - 24px);
-                max-width: 280px;
-            }
-        }
-    }
-
-    @media (max-width: 992px) {
-        padding: clamp(2.5rem, 8vw, 4rem) clamp(0.75rem, 5vw, 2rem);
-
-        .statistics-section {
-            .statistics-card {
-                flex: 1 1 calc(50% - 24px);
-                max-width: 320px;
-                min-width: 220px;
-            }
-        }
     }
 
     @media (max-width: 768px) {
-        padding: clamp(2.25rem, 9vw, 3rem) clamp(0.75rem, 6vw, 1.75rem);
+        padding: clamp(2.5rem, 8vh, 3.5rem) clamp(1rem, 8vw, 2rem);
 
         .statistics-section {
-            .statistics-card {
-                flex: 1 1 100%;
-                max-width: 320px;
-                min-width: 200px;
-                padding: 24px 20px;
-            }
-
-            h2 {
-                font-size: 1.75rem;
+            .statistics-section-title {
+                margin-bottom: clamp(1.75rem, 6vh, 2.5rem);
             }
         }
     }
 
     @media (max-width: 480px) {
-        padding: clamp(2rem, 10vw, 2.75rem) clamp(0.5rem, 6vw, 1.25rem);
+        padding: clamp(2.25rem, 10vh, 3rem) clamp(0.85rem, 8vw, 1.5rem);
 
         .statistics-section {
-            .statistics-container {
-                padding: 0 clamp(0.75rem, 6vw, 1.25rem);
+            padding-inline: 0;
+
+            .statistics-row {
+                gap: clamp(1.25rem, 6vw, 1.75rem);
             }
 
             .statistics-card {
-                max-width: 280px;
-                min-width: 180px;
-                padding: 20px 18px;
-            }
-
-            h2 {
-                font-size: 1.5rem;
+                padding: clamp(1.5rem, 10vw, 2.25rem);
             }
         }
     }

--- a/src/app/data/stats.data.ts
+++ b/src/app/data/stats.data.ts
@@ -4,19 +4,19 @@ export const statsData: Stats = {
     it: {
         title: 'Numeri chiave',
         stats: [
-            { icon: 'schedule', label: 'Ore totali', valueSuffix: 'ore di sviluppo' },
-            { icon: 'today', label: 'Mesi di esperienza', valueSuffix: 'mesi su progetti reali' },
-            { icon: 'work', label: 'Progetti consegnati', valueSuffix: 'progetti seguiti end-to-end' },
-            { icon: 'code', label: 'Stack principale' },
+            { icon: 'schedule', label: 'Ore', valueSuffix: 'di sviluppo' },
+            { icon: 'today', label: 'Mesi', valueSuffix: 'di esperienza reale' },
+            { icon: 'work', label: 'Progetti', valueSuffix: 'completati' },
+            { icon: 'code', label: 'Stack' },
         ]
     },
     en: {
         title: 'Key numbers',
         stats: [
-            { icon: 'schedule', label: 'Total hours', valueSuffix: 'engineering hours' },
-            { icon: 'today', label: 'Experience months', valueSuffix: 'months on real projects' },
-            { icon: 'work', label: 'Projects shipped', valueSuffix: 'end-to-end builds' },
-            { icon: 'code', label: 'Core stack' },
+            { icon: 'schedule', label: 'Hours', valueSuffix: 'of coding' },
+            { icon: 'today', label: 'Months', valueSuffix: 'hands-on' },
+            { icon: 'work', label: 'Projects', valueSuffix: 'delivered' },
+            { icon: 'code', label: 'Stack' },
         ]
     }
 };


### PR DESCRIPTION
## Summary
- modernize the statistics section with a full-height responsive layout, refreshed gradients, and larger icons
- refine typography and card spacing for better readability on mobile and desktop
- shorten Italian and English stat labels/suffixes to deliver more concise copy

## Testing
- not run (npm registry returned 403 during dependency installation)


------
https://chatgpt.com/codex/tasks/task_e_68e6919e56e0832bb545e5b77aba577e