### PR TITLE
Remove Sentry error tracking integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,13 +75,12 @@ This repository contains a portfolio application built with **Angular 18**. It u
    ```
 
 ### Environment configuration
-Analytics, the contact form and error tracking are configured through the Angular environment files under [`src/environments/`](src/environments/).
+Analytics and the contact form are configured through the Angular environment files under [`src/environments/`](src/environments/).
 Update the following keys before publishing:
 
 - `gaTrackingId` – Google Analytics 4 tracking code (the GA measurement ID is public and ships with the client bundle).
 - `formspreeEndpoint` – Formspree project endpoint used by `EmailService` (it is also public because it must be reachable from the browser).
-- `enableAnalytics` / `enableErrorTracking` – Toggle for loading the external scripts.
-- `sentryDsn` and `sentryTracesSampleRate` – Sentry credentials and trace sampling rate (default `1`). Set the rate to `0` to disable tracing while keeping error reporting enabled.
+- `enableAnalytics` – Toggle for loading the Google Analytics script.
 
 Keep the production file (`environment.prod.ts`) free from private secrets. Both identifiers are safe to expose, but you can keep the real production values outside of git by generating the file during the build. Run `npm run configure:env:prod` locally or in CI to write the production configuration from environment variables:
 
@@ -92,12 +91,9 @@ Keep the production file (`environment.prod.ts`) free from private secrets. Both
     NG_APP_GA_TRACKING_ID: ${{ secrets.GA_TRACKING_ID }}
     NG_APP_FORMSPREE_ENDPOINT: ${{ secrets.FORMSPREE_ENDPOINT }}
     NG_APP_ENABLE_ANALYTICS: 'true'
-    NG_APP_ENABLE_ERROR_TRACKING: 'true'
-    NG_APP_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-    NG_APP_SENTRY_TRACES_SAMPLE_RATE: '0.5'
 ```
 
-The configuration script also accepts the unprefixed keys (`GA_TRACKING_ID`, `FORMSPREE_ENDPOINT`, `SENTRY_DSN`, `ENABLE_ANALYTICS`, `ENABLE_ERROR_TRACKING`, `SENTRY_TRACES_SAMPLE_RATE`). This makes it easier to reuse existing provider secret names without duplicating values.
+The configuration script also accepts the unprefixed keys (`GA_TRACKING_ID`, `FORMSPREE_ENDPOINT`, `ENABLE_ANALYTICS`). This makes it easier to reuse existing provider secret names without duplicating values.
 
 Store the secrets in the repository or organisation settings (Formspree values can live in secrets for convenience even though they are public). Refer to [docs/environment-configuration.md](docs/environment-configuration.md) for a more detailed checklist.
 
@@ -199,13 +195,12 @@ La struttura del progetto è descritta nella sezione [Project Structure](#projec
    ```
 
 ### Configurazione dell'ambiente
-Le impostazioni di analytics, del modulo contatti e del monitoraggio errori sono definite nei file Angular in [`src/environments/`](src/environments/).
+Le impostazioni di analytics e del modulo contatti sono definite nei file Angular in [`src/environments/`](src/environments/).
 Aggiorna le seguenti chiavi prima di pubblicare:
 
 - `gaTrackingId` – codice di tracciamento di Google Analytics 4 (il measurement ID è pubblico e distribuito insieme al bundle client).
 - `formspreeEndpoint` – endpoint Formspree utilizzato da `EmailService` (anch'esso pubblico perché deve essere raggiungibile dal browser).
-- `enableAnalytics` / `enableErrorTracking` – flag per caricare gli script esterni.
-- `sentryDsn` e `sentryTracesSampleRate` – credenziali di Sentry e frequenza di campionamento delle tracce (predefinita `1`). Impostare il valore a `0` disattiva le tracce lasciando attivo l'invio degli errori.
+- `enableAnalytics` – flag per caricare lo script di Google Analytics.
 
 Mantieni il file di produzione (`environment.prod.ts`) libero da credenziali private. Entrambi gli identificativi possono essere pubblici, ma puoi tenere i valori reali fuori da git generando il file durante la build. Esegui `npm run configure:env:prod` in locale o in CI per scrivere la configurazione di produzione partendo dalle variabili d'ambiente:
 
@@ -216,9 +211,6 @@ Mantieni il file di produzione (`environment.prod.ts`) libero da credenziali pri
     NG_APP_GA_TRACKING_ID: ${{ secrets.GA_TRACKING_ID }}
     NG_APP_FORMSPREE_ENDPOINT: ${{ secrets.FORMSPREE_ENDPOINT }}
     NG_APP_ENABLE_ANALYTICS: 'true'
-    NG_APP_ENABLE_ERROR_TRACKING: 'true'
-    NG_APP_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-    NG_APP_SENTRY_TRACES_SAMPLE_RATE: '0.5'
 ```
 
 Archivia i secret nelle impostazioni del repository o dell'organizzazione (puoi salvare anche l'endpoint Formspree per praticità, pur essendo pubblico). Consulta [docs/environment-configuration.md](docs/environment-configuration.md) per una checklist dettagliata.
@@ -313,13 +305,12 @@ Die Projektstruktur findest du in der gemeinsamen Sektion [Project Structure](#p
    ```
 
 ### Umgebungsvariablen
-Analytics, Kontaktformular und Fehlüberwachung werden über die Angular-Umgebungsdateien unter [`src/environments/`](src/environments/) gesteuert.
+Analytics und das Kontaktformular werden über die Angular-Umgebungsdateien unter [`src/environments/`](src/environments/) gesteuert.
 Aktualisiere vor einer Veröffentlichung folgende Schlüssel:
 
 - `gaTrackingId` – Google-Analytics-4-Tracking-ID (die Measurement-ID ist öffentlich und wird mit dem Client-Bundle ausgeliefert).
 - `formspreeEndpoint` – Formspree-Endpunkt, den `EmailService` verwendet (ebenfalls öffentlich, da der Browser ihn erreichen muss).
-- `enableAnalytics` / `enableErrorTracking` – Schalter zum Laden der externen Skripte.
-- `sentryDsn` und `sentryTracesSampleRate` – Sentry-Zugangsdaten und Sampling-Rate für Traces (Standard `1`). Ein Wert von `0` deaktiviert Traces, Fehler werden dennoch gemeldet.
+- `enableAnalytics` – Schalter zum Laden des Google-Analytics-Skripts.
 
 Halte die Produktionsdatei (`environment.prod.ts`) frei von privaten Zugangsdaten. Beide Kennungen dürfen zwar öffentlich sein, du kannst die produktiven Werte jedoch außerhalb von Git belassen, indem du die Datei während des Builds generierst. Führe `npm run configure:env:prod` lokal oder in CI aus, um die Produktionskonfiguration aus Umgebungsvariablen zu schreiben:
 
@@ -330,9 +321,6 @@ Halte die Produktionsdatei (`environment.prod.ts`) frei von privaten Zugangsdate
     NG_APP_GA_TRACKING_ID: ${{ secrets.GA_TRACKING_ID }}
     NG_APP_FORMSPREE_ENDPOINT: ${{ secrets.FORMSPREE_ENDPOINT }}
     NG_APP_ENABLE_ANALYTICS: 'true'
-    NG_APP_ENABLE_ERROR_TRACKING: 'true'
-    NG_APP_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-    NG_APP_SENTRY_TRACES_SAMPLE_RATE: '0.5'
 ```
 
 Hinterlege die Secrets in den Repository- oder Organisations-Einstellungen (auch der Formspree-Endpunkt kann dort aus Gründen der Übersichtlichkeit liegen, obwohl er öffentlich ist). Weitere Details findest du in [docs/environment-configuration.md](docs/environment-configuration.md).
@@ -407,13 +395,12 @@ La estructura es la misma descrita en [Project Structure](#project-structure) y 
    ```
 
 ### Configuración de entorno
-La analítica, el formulario de contacto y el seguimiento de errores se controlan mediante los archivos de entorno de Angular que se encuentran en [`src/environments/`](src/environments/).
+La analítica y el formulario de contacto se controlan mediante los archivos de entorno de Angular que se encuentran en [`src/environments/`](src/environments/).
 Actualiza las siguientes claves antes de desplegar:
 
 - `gaTrackingId` – identificador de seguimiento de Google Analytics 4 (el measurement ID es público y se entrega con el bundle del cliente).
 - `formspreeEndpoint` – endpoint de Formspree usado por `EmailService` (también público porque el navegador debe acceder a él).
-- `enableAnalytics` / `enableErrorTracking` – interruptores para cargar los scripts externos.
-- `sentryDsn` y `sentryTracesSampleRate` – credenciales de Sentry y tasa de muestreo de las trazas (valor predeterminado `1`). Un valor de `0` desactiva las trazas sin afectar el envío de errores.
+- `enableAnalytics` – interruptor para cargar el script de Google Analytics.
 
 Mantén el archivo de producción (`environment.prod.ts`) libre de credenciales privadas. Ambos identificadores pueden ser públicos, pero puedes mantener los valores reales fuera de git generando el archivo durante la compilación. Ejecuta `npm run configure:env:prod` en local o en CI para escribir la configuración de producción a partir de variables de entorno:
 
@@ -424,9 +411,6 @@ Mantén el archivo de producción (`environment.prod.ts`) libre de credenciales 
     NG_APP_GA_TRACKING_ID: ${{ secrets.GA_TRACKING_ID }}
     NG_APP_FORMSPREE_ENDPOINT: ${{ secrets.FORMSPREE_ENDPOINT }}
     NG_APP_ENABLE_ANALYTICS: 'true'
-    NG_APP_ENABLE_ERROR_TRACKING: 'true'
-    NG_APP_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-    NG_APP_SENTRY_TRACES_SAMPLE_RATE: '0.5'
 ```
 
 Guarda los secretos en la configuración del repositorio u organización (puedes incluir el endpoint de Formspree por comodidad, aunque sea público). Consulta [docs/environment-configuration.md](docs/environment-configuration.md) para un listado detallado.

--- a/docs/environment-configuration.md
+++ b/docs/environment-configuration.md
@@ -1,6 +1,6 @@
 # Environment configuration
 
-This document centralises the steps required to keep analytics, the contact form and error tracking configured across local development and CI builds.
+This document centralises the steps required to keep analytics and the contact form configured across local development and CI builds.
 
 ## Available keys
 
@@ -9,13 +9,10 @@ Both `src/environments/environment.ts` (development) and `src/environments/envir
 - `gaTrackingId` – Google Analytics 4 tracking identifier (the measurement ID is public and ships with the client bundle).
 - `formspreeEndpoint` – Formspree endpoint consumed by `EmailService` (public value; safe to expose but you may keep it outside git for convenience).
 - `enableAnalytics` – Enables Google Analytics initialisation.
-- `enableErrorTracking` – Activates Sentry error handlers.
-- `sentryDsn` – Sentry DSN.
-- `sentryTracesSampleRate` – Sampling rate applied to traces (defaults to `1`). Set this to `0` to disable tracing without affecting error reporting.
 
 ## Local development
 
-1. Keep `enableAnalytics` and `enableErrorTracking` disabled while developing unless you want to interact with the real services.
+1. Keep `enableAnalytics` disabled while developing unless you want to interact with the real services.
 2. When testing integrations locally, temporarily set the desired IDs in `environment.ts` or export them while running the generator:
    ```bash
    NG_APP_FORMSPREE_ENDPOINT="https://formspree.io/f/your-form" \
@@ -28,7 +25,7 @@ Both `src/environments/environment.ts` (development) and `src/environments/envir
 
 ## Continuous integration
 
-Provide the analytics and Sentry secrets as encrypted values in the CI system (for GitHub Actions use **Settings → Secrets and variables**). Although both identifiers are public once the site is deployed, keeping them in secrets ensures the repository stays environment-agnostic. Generate the production file during the build with `npm run configure:env:prod`:
+Provide the analytics secrets as encrypted values in the CI system (for GitHub Actions use **Settings → Secrets and variables**). Although the identifiers are public once the site is deployed, keeping them in secrets ensures the repository stays environment-agnostic. Generate the production file during the build with `npm run configure:env:prod`:
 
 ```yaml
 - name: Configure Angular environment
@@ -37,9 +34,6 @@ Provide the analytics and Sentry secrets as encrypted values in the CI system (f
     NG_APP_GA_TRACKING_ID: ${{ secrets.GA_TRACKING_ID }}
     NG_APP_FORMSPREE_ENDPOINT: ${{ secrets.FORMSPREE_ENDPOINT }}
     NG_APP_ENABLE_ANALYTICS: 'true'
-    NG_APP_ENABLE_ERROR_TRACKING: 'true'
-    NG_APP_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-    NG_APP_SENTRY_TRACES_SAMPLE_RATE: '0.5'
 ```
 
-Adjust the sampling rate and toggles as needed per environment. You can swap the variables for the unprefixed equivalents (for example `GA_TRACKING_ID` or `SENTRY_DSN`) when your CI already exposes them with those names. Store the secrets in your CI system (Formspree can live there even if it is public) so each build writes a fresh `environment.prod.ts` without committing the real identifiers to git.
+Adjust the toggles as needed per environment. You can swap the variables for the unprefixed equivalents (for example `GA_TRACKING_ID`) when your CI already exposes them with those names. Store the secrets in your CI system (Formspree can live there even if it is public) so each build writes a fresh `environment.prod.ts` without committing the real identifiers to git.

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "@emailjs/browser": "^4.4.1",
         "@ngx-translate/core": "^16.0.3",
         "@ngx-translate/http-loader": "^16.0.0",
-        "@sentry/angular": "^10.20.0",
         "express": "^4.18.2",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
@@ -5651,101 +5650,6 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0",
         "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
         "yarn": ">= 1.13.0"
-      }
-    },
-    "node_modules/@sentry-internal/browser-utils": {
-      "version": "10.20.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.20.0.tgz",
-      "integrity": "sha512-9+NybrYs+dEM2iW5uRAYEhKkNK0XhDea5jovtDUXEvdSCMJFcdR88uztkftnCur45/hpvbgSULsGPUdHPb5ITw==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "10.20.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry-internal/feedback": {
-      "version": "10.20.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.20.0.tgz",
-      "integrity": "sha512-R/eGLKl7WDccLKBorEbyTsy5b99w/k4v80SntE8HL2rsO7DCDXma8TGmtHd+iZnw8dUci+EVrw7LbeGSgf3QzA==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "10.20.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry-internal/replay": {
-      "version": "10.20.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.20.0.tgz",
-      "integrity": "sha512-+XPYp0CuJnf+c36/c+hHrY6wAPHCdnqllZeyU7+9LAiKsdhN8Oo4eF1v5zd097qDZBg1NrKhU44ScJIzz+vygw==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry-internal/browser-utils": "10.20.0",
-        "@sentry/core": "10.20.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry-internal/replay-canvas": {
-      "version": "10.20.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.20.0.tgz",
-      "integrity": "sha512-8DBawFi4F4e2Cu2ToiitCnYsK8idrDOv66Vq+N6c8e3qFitTTuoPQwOihb2+HY4CB06ABPW3WvfZntJJmsf91w==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry-internal/replay": "10.20.0",
-        "@sentry/core": "10.20.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry/angular": {
-      "version": "10.20.0",
-      "resolved": "https://registry.npmjs.org/@sentry/angular/-/angular-10.20.0.tgz",
-      "integrity": "sha512-oyWeLc/SJFEG7eY4deNNL9Un8N7+iB7jYP0VXav77yEy7SueWhP4jkX1eWleGBwzUvZNjOZakx1JgVP5bpvUyw==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/browser": "10.20.0",
-        "@sentry/core": "10.20.0",
-        "tslib": "^2.4.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@angular/common": ">= 14.x <= 20.x",
-        "@angular/core": ">= 14.x <= 20.x",
-        "@angular/router": ">= 14.x <= 20.x",
-        "rxjs": "^6.5.5 || ^7.x"
-      }
-    },
-    "node_modules/@sentry/browser": {
-      "version": "10.20.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.20.0.tgz",
-      "integrity": "sha512-zcf8HwFiRbzjZL9KbLev44eEOf+yl+3svQbs2BlR2KAYGaB10swV5abij0UTTGO7ClnqUZdcGpwiyyfPS6mjHg==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry-internal/browser-utils": "10.20.0",
-        "@sentry-internal/feedback": "10.20.0",
-        "@sentry-internal/replay": "10.20.0",
-        "@sentry-internal/replay-canvas": "10.20.0",
-        "@sentry/core": "10.20.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry/core": {
-      "version": "10.20.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.20.0.tgz",
-      "integrity": "sha512-S291KihnOIB8i7mVJIJBVHBMcCfIoY/KDJBHEfBoHY9M56g2An4FVhM9+/xR85+IoMkTySdXN08k9LEyQz4FpQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@sigstore/bundle": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@emailjs/browser": "^4.4.1",
     "@ngx-translate/core": "^16.0.3",
     "@ngx-translate/http-loader": "^16.0.0",
-    "@sentry/angular": "^10.20.0",
     "express": "^4.18.2",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",

--- a/scripts/write-environment.mjs
+++ b/scripts/write-environment.mjs
@@ -20,32 +20,14 @@ const parseBoolean = (value, fallback) => {
   return Boolean(value);
 };
 
-const parseNumber = (value, fallback) => {
-  if (value === undefined || value === '') {
-    return fallback;
-  }
-
-  const parsed = Number.parseFloat(value);
-  return Number.isNaN(parsed) ? fallback : parsed;
-};
-
 const readEnv = (...keys) => keys.map((key) => process.env[key]).find((value) => value !== undefined);
 
 const gaTrackingId = readEnv('NG_APP_GA_TRACKING_ID', 'GA_TRACKING_ID') ?? '';
 const formspreeEndpoint = readEnv('NG_APP_FORMSPREE_ENDPOINT', 'FORMSPREE_ENDPOINT') ?? '';
-const sentryDsn = readEnv('NG_APP_SENTRY_DSN', 'SENTRY_DSN') ?? '';
 
 const enableAnalytics = parseBoolean(
   readEnv('NG_APP_ENABLE_ANALYTICS', 'ENABLE_ANALYTICS'),
   gaTrackingId.length > 0,
-);
-const enableErrorTracking = parseBoolean(
-  readEnv('NG_APP_ENABLE_ERROR_TRACKING', 'ENABLE_ERROR_TRACKING'),
-  sentryDsn.length > 0,
-);
-const sentryTracesSampleRate = parseNumber(
-  readEnv('NG_APP_SENTRY_TRACES_SAMPLE_RATE', 'SENTRY_TRACES_SAMPLE_RATE'),
-  1,
 );
 
 const content = `import { EnvironmentConfig } from './environment.config';
@@ -55,9 +37,6 @@ export const environment: EnvironmentConfig = {
   gaTrackingId: '${escapeForTs(gaTrackingId)}',
   formspreeEndpoint: '${escapeForTs(formspreeEndpoint)}',
   enableAnalytics: ${enableAnalytics},
-  enableErrorTracking: ${enableErrorTracking},
-  sentryDsn: '${escapeForTs(sentryDsn)}',
-  sentryTracesSampleRate: ${sentryTracesSampleRate},
 };
 
 export type { EnvironmentConfig } from './environment.config';

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,6 +1,5 @@
-import { APP_INITIALIZER, ApplicationConfig, ErrorHandler, provideZoneChangeDetection } from '@angular/core';
-import { provideRouter, Router } from '@angular/router';
-import * as Sentry from '@sentry/angular';
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { provideRouter } from '@angular/router';
 import { routes } from './app.routes';
 import { provideClientHydration } from '@angular/platform-browser';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
@@ -8,27 +7,6 @@ import { provideHttpClient } from '@angular/common/http';
 import { MAT_ICON_DEFAULT_OPTIONS } from '@angular/material/icon';
 import { environment } from '../environments/environment';
 import { APP_ENVIRONMENT } from './tokens/environment.token';
-
-const enableSentry = environment.enableErrorTracking && !!environment.sentryDsn;
-
-const errorTrackingProviders = enableSentry
-  ? [
-    {
-      provide: ErrorHandler,
-      useValue: Sentry.createErrorHandler(),
-    },
-    {
-      provide: Sentry.TraceService,
-      deps: [Router],
-    },
-    {
-      provide: APP_INITIALIZER,
-      useFactory: () => () => { },
-      deps: [Sentry.TraceService],
-      multi: true,
-    },
-  ]
-  : [];
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -42,6 +20,5 @@ export const appConfig: ApplicationConfig = {
       useValue: { fontSet: 'material-symbols-rounded' },
     },
     { provide: APP_ENVIRONMENT, useValue: environment },
-    ...errorTrackingProviders,
   ],
 };

--- a/src/app/components/contact-me/contact-me.component.spec.ts
+++ b/src/app/components/contact-me/contact-me.component.spec.ts
@@ -19,9 +19,6 @@ describe('ContactMeComponent', () => {
     gaTrackingId: '',
     formspreeEndpoint: '',
     enableAnalytics: false,
-    enableErrorTracking: false,
-    sentryDsn: '',
-    sentryTracesSampleRate: 0,
   };
 
   /**

--- a/src/app/pages/home/home.component.spec.ts
+++ b/src/app/pages/home/home.component.spec.ts
@@ -22,9 +22,6 @@ describe('HomeComponent', () => {
             gaTrackingId: 'test-tracking-id',
             formspreeEndpoint: '',
             enableAnalytics: false,
-            enableErrorTracking: false,
-            sentryDsn: '',
-            sentryTracesSampleRate: 0,
           } satisfies EnvironmentConfig,
         },
       ]

--- a/src/app/services/analytics.service.spec.ts
+++ b/src/app/services/analytics.service.spec.ts
@@ -11,9 +11,6 @@ describe('AnalyticsService', () => {
     gaTrackingId: 'G-TEST123',
     formspreeEndpoint: '',
     enableAnalytics: true,
-    enableErrorTracking: false,
-    sentryDsn: '',
-    sentryTracesSampleRate: 0,
   };
 
   let service: AnalyticsService | undefined;

--- a/src/app/services/email.service.spec.ts
+++ b/src/app/services/email.service.spec.ts
@@ -13,9 +13,6 @@ describe('EmailService', () => {
     gaTrackingId: 'G-1234567890',
     formspreeEndpoint,
     enableAnalytics: true,
-    enableErrorTracking: true,
-    sentryDsn: 'https://example@sentry.test/1',
-    sentryTracesSampleRate: 0,
   };
 
   beforeEach(() => {

--- a/src/environments/environment.config.ts
+++ b/src/environments/environment.config.ts
@@ -3,8 +3,4 @@ export interface EnvironmentConfig {
   gaTrackingId: string;
   formspreeEndpoint: string;
   enableAnalytics: boolean;
-  enableErrorTracking: boolean;
-  sentryDsn: string;
-  /** Sampling rate for performance traces. Errors are always reported when tracking is enabled. */
-  sentryTracesSampleRate: number;
 }

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -5,9 +5,6 @@ export const environment: EnvironmentConfig = {
   gaTrackingId: '',
   formspreeEndpoint: '',
   enableAnalytics: false,
-  enableErrorTracking: true,
-  sentryDsn: 'https://dfe186d21a11e5397b5baf0c88109a28@o4510193552719872.ingest.de.sentry.io/4510198684713040',
-  sentryTracesSampleRate: 1,
 };
 
 export type { EnvironmentConfig } from './environment.config';

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -5,9 +5,6 @@ export const environment: EnvironmentConfig = {
   gaTrackingId: '',
   formspreeEndpoint: '',
   enableAnalytics: false,
-  enableErrorTracking: true,
-  sentryDsn: 'https://49717dbbe605ee8999979f2b47166584@o4510193552719872.ingest.de.sentry.io/4510197906538576',
-  sentryTracesSampleRate: 1,
 };
 
 export type { EnvironmentConfig } from './environment.config';

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,24 +1,5 @@
 import { bootstrapApplication } from '@angular/platform-browser';
 import { appConfig } from './app/app.config';
 import { AppComponent } from './app/app.component';
-import { environment } from './environments/environment';
-import * as Sentry from '@sentry/angular';
-import { browserTracingIntegration } from '@sentry/angular';
-
-const enableSentry = environment.enableErrorTracking && !!environment.sentryDsn;
-
-if (enableSentry) {
-  const tracesSampleRate = Math.min(Math.max(environment.sentryTracesSampleRate ?? 1, 0), 1);
-
-  Sentry.init({
-    dsn: environment.sentryDsn,
-    integrations: [
-      browserTracingIntegration(), 
-    ],
-    tracePropagationTargets: ['http://localhost:4200/', 'https://diegofcj.github.io/portfolio/'],
-    sendDefaultPii: true,
-    tracesSampleRate,
-  });
-}
 
 bootstrapApplication(AppComponent, appConfig).catch(err => console.error(err));


### PR DESCRIPTION
## Summary
- remove the Sentry dependency and all runtime initialization
- simplify the environment configuration, scripts, docs, and tests to drop Sentry-specific fields

## Testing
- npm test -- --watch=false *(fails: ng: not found in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fb88c87814832b9be2700e62fd3cc1