### PR TITLE
Ensure preview deployments configure environment

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -48,6 +48,16 @@ jobs:
       - name: Run unit tests
         run: npm test -- --watch=false --browsers=ChromeHeadless
 
+      - name: Configure preview environment
+        env:
+          NG_APP_GA_TRACKING_ID: ${{ secrets.GA_TRACKING_ID }}
+          NG_APP_FORMSPREE_ENDPOINT: ${{ secrets.FORMSPREE_ENDPOINT }}
+          NG_APP_ENABLE_ANALYTICS: ${{ secrets.ENABLE_ANALYTICS }}
+          NG_APP_ENABLE_ERROR_TRACKING: ${{ secrets.ENABLE_ERROR_TRACKING }}
+          NG_APP_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          NG_APP_SENTRY_TRACES_SAMPLE_RATE: ${{ secrets.SENTRY_TRACES_SAMPLE_RATE }}
+        run: npm run configure:env:prod
+
       - name: Build preview
         run: npm run build -- --output-path=dist/portfolio --base-href="$PREVIEW_BASE_HREF"
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ The Express server listens on `http://localhost:4000` by default.
   ```bash
   git tag v1.0.0 && git push origin v1.0.0
   ```
-- **Pull Request preview** – Each open PR gets its own preview at `https://<github-username>.github.io/portfolio/previews/pr-<PR_NUMBER>/`. Once the `Deploy Preview to GitHub Pages / build-and-deploy` job succeeds, the same URL is shown in the PR environments panel.
+- **Pull Request preview** – Each open PR gets its own preview at `https://<github-username>.github.io/portfolio/previews/pr-<PR_NUMBER>/`. Once the `Deploy Preview to GitHub Pages / build-and-deploy` job succeeds, the same URL is shown in the PR environments panel. Configure the repository secrets `GA_TRACKING_ID`, `FORMSPREE_ENDPOINT`, `ENABLE_ANALYTICS`, `ENABLE_ERROR_TRACKING`, `SENTRY_DSN` and `SENTRY_TRACES_SAMPLE_RATE` so the preview workflow can run `npm run configure:env:prod` before building.
 
 ### License
 This repository is distributed under the [MIT License](LICENSE). Key dependencies such as Angular and Express also adopt the MIT terms, ensuring the stack remains permissively licensed.
@@ -267,7 +267,7 @@ Il server Express è in ascolto su `http://localhost:4000`.
   ```bash
   git tag v1.0.0 && git push origin v1.0.0
   ```
-- **Anteprima delle Pull Request** – Ogni PR aperta pubblica un'anteprima su `https://<github-username>.github.io/portfolio/previews/pr-<NUMERO_PR>/`. Quando il job `Deploy Preview to GitHub Pages / build-and-deploy` va a buon fine, lo stesso link compare anche nel pannello degli ambienti della PR.
+- **Anteprima delle Pull Request** – Ogni PR aperta pubblica un'anteprima su `https://<github-username>.github.io/portfolio/previews/pr-<NUMERO_PR>/`. Quando il job `Deploy Preview to GitHub Pages / build-and-deploy` va a buon fine, lo stesso link compare anche nel pannello degli ambienti della PR. Imposta i secret del repository `GA_TRACKING_ID`, `FORMSPREE_ENDPOINT`, `ENABLE_ANALYTICS`, `ENABLE_ERROR_TRACKING`, `SENTRY_DSN` e `SENTRY_TRACES_SAMPLE_RATE` per permettere al workflow di eseguire `npm run configure:env:prod` prima della build.
 
 ### Licenza
 Questo repository è distribuito con [licenza MIT](LICENSE). Anche dipendenze principali come Angular ed Express adottano condizioni MIT, mantenendo l'intero stack con una licenza permissiva.


### PR DESCRIPTION
## Summary
- run the production environment configuration script during preview builds using the same secrets as production
- document the secrets required for preview deployments in the README (English and Italian sections)

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fb98971b1c832bb87ebadd17ea6706