### PR TITLE
feat: update analytics consent handling

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -66,7 +66,7 @@ describe('AppComponent', () => {
       getCurrentLanguage: jasmine.createSpy('getCurrentLanguage').and.callFake(() => languageSubject.value),
     };
 
-    analyticsService = jasmine.createSpyObj<AnalyticsService>('AnalyticsService', ['initialize', 'trackPageView']);
+    analyticsService = jasmine.createSpyObj<AnalyticsService>('AnalyticsService', ['initialize', 'trackPageView', 'updateConsent']);
 
     await TestBed.configureTestingModule({
       imports: [RouterTestingModule, AppComponent],
@@ -90,18 +90,27 @@ describe('AppComponent', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     expect(analyticsService.initialize).not.toHaveBeenCalled();
+    expect(analyticsService.updateConsent).not.toHaveBeenCalled();
 
     const app = fixture.componentInstance;
     app.onConsentChange(true);
 
+    expect(analyticsService.updateConsent).toHaveBeenCalledTimes(1);
+    expect(analyticsService.updateConsent).toHaveBeenCalledWith(true);
     expect(analyticsService.initialize).toHaveBeenCalledTimes(1);
 
     app.onConsentChange(true);
     expect(analyticsService.initialize).toHaveBeenCalledTimes(1);
+    expect(analyticsService.updateConsent).toHaveBeenCalledTimes(2);
 
     app.onConsentChange(false);
+    expect(analyticsService.updateConsent).toHaveBeenCalledTimes(3);
+    expect(analyticsService.updateConsent).toHaveBeenCalledWith(false);
     app.onConsentChange(true);
     expect(analyticsService.initialize).toHaveBeenCalledTimes(2);
+    expect(analyticsService.updateConsent).toHaveBeenCalledTimes(4);
+    const consentCalls = analyticsService.updateConsent.calls.allArgs();
+    expect(consentCalls).toEqual([[true], [true], [false], [true]]);
   });
 
   it('should set the document title to "Portfolio di Diego" for Italian', () => {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -72,10 +72,14 @@ export class AppComponent implements OnInit {
       return;
     }
 
-    if (consentGranted && !this.analyticsConsentGranted) {
-      this.analyticsService.initialize();
-      this.analyticsConsentGranted = true;
-    } else if (!consentGranted) {
+    if (consentGranted) {
+      this.analyticsService.updateConsent(true);
+      if (!this.analyticsConsentGranted) {
+        this.analyticsService.initialize();
+        this.analyticsConsentGranted = true;
+      }
+    } else {
+      this.analyticsService.updateConsent(false);
       this.analyticsConsentGranted = false;
     }
   }

--- a/src/app/services/analytics.service.ts
+++ b/src/app/services/analytics.service.ts
@@ -3,9 +3,11 @@ import { DOCUMENT, isPlatformBrowser } from '@angular/common';
 import { EnvironmentConfig } from '../../environments/environment';
 import { APP_ENVIRONMENT } from '../tokens/environment.token';
 
+type GtagFunction = (...args: unknown[]) => void;
+
 interface AnalyticsWindow extends Window {
   dataLayer: unknown[];
-  gtag?: (...args: unknown[]) => void;
+  gtag?: GtagFunction;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -124,7 +126,7 @@ export class AnalyticsService {
     head.appendChild(script);
   }
 
-  private ensureAnalyticsStubs(win: AnalyticsWindow): void {
+  private ensureAnalyticsStubs(win: AnalyticsWindow): asserts win is AnalyticsWindow & { gtag: GtagFunction } {
     win.dataLayer = win.dataLayer || [];
     win.gtag = win.gtag || function gtag() {
       // eslint-disable-next-line prefer-rest-params


### PR DESCRIPTION
## Summary
- add an updateConsent helper that primes the analytics stubs and dispatches default and updated consent states
- invoke consent updates from the app component before bootstrapping analytics and whenever consent is revoked
- extend the analytics and app component specs to cover the new consent signalling behaviour

## Testing
- `npm run test:headless` *(fails: missing Puppeteer/Angular packages because the registry is not accessible from the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fba3bcca6c832ba5d0369c11a37f55