### PR TITLE
feat: handle consent updates before analytics bootstrap

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -66,7 +66,7 @@ describe('AppComponent', () => {
       getCurrentLanguage: jasmine.createSpy('getCurrentLanguage').and.callFake(() => languageSubject.value),
     };
 
-    analyticsService = jasmine.createSpyObj<AnalyticsService>('AnalyticsService', ['initialize', 'trackPageView']);
+    analyticsService = jasmine.createSpyObj<AnalyticsService>('AnalyticsService', ['initialize', 'trackPageView', 'updateConsent']);
 
     await TestBed.configureTestingModule({
       imports: [RouterTestingModule, AppComponent],
@@ -94,13 +94,17 @@ describe('AppComponent', () => {
     const app = fixture.componentInstance;
     app.onConsentChange(true);
 
+    expect(analyticsService.updateConsent).toHaveBeenCalledWith(true);
     expect(analyticsService.initialize).toHaveBeenCalledTimes(1);
 
     app.onConsentChange(true);
+    expect(analyticsService.updateConsent).toHaveBeenCalledWith(true);
     expect(analyticsService.initialize).toHaveBeenCalledTimes(1);
 
     app.onConsentChange(false);
+    expect(analyticsService.updateConsent).toHaveBeenCalledWith(false);
     app.onConsentChange(true);
+    expect(analyticsService.updateConsent).toHaveBeenCalledWith(true);
     expect(analyticsService.initialize).toHaveBeenCalledTimes(2);
   });
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -72,12 +72,13 @@ export class AppComponent implements OnInit {
       return;
     }
 
+    this.analyticsService.updateConsent(consentGranted);
+
     if (consentGranted && !this.analyticsConsentGranted) {
       this.analyticsService.initialize();
-      this.analyticsConsentGranted = true;
-    } else if (!consentGranted) {
-      this.analyticsConsentGranted = false;
     }
+
+    this.analyticsConsentGranted = consentGranted;
   }
 
   private updatePageTitle(language: LanguageCode): void {


### PR DESCRIPTION
## Summary
- initialize the Google Analytics data layer before loading the script and expose a consent update hook
- send default-denied and update consent events from the analytics service and wire them through the app component
- extend service and component unit tests to cover consent signalling and gated initialization

## Testing
- CHROME_BIN=$(node -p "require('puppeteer').executablePath()") npx ng test --watch=false --browsers=ChromeHeadlessPuppeteer *(fails: puppeteer dependency unavailable in the environment and npm registry 403)*

------
https://chatgpt.com/codex/tasks/task_e_68fba67952d8832ba6886c7e31ffa75d