### PR TITLE
feat: improve analytics consent management

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -66,7 +66,10 @@ describe('AppComponent', () => {
       getCurrentLanguage: jasmine.createSpy('getCurrentLanguage').and.callFake(() => languageSubject.value),
     };
 
-    analyticsService = jasmine.createSpyObj<AnalyticsService>('AnalyticsService', ['initialize', 'trackPageView', 'updateConsent']);
+    analyticsService = jasmine.createSpyObj<AnalyticsService>(
+      'AnalyticsService',
+      ['initialize', 'trackPageView', 'updateConsent'],
+    );
 
     await TestBed.configureTestingModule({
       imports: [RouterTestingModule, AppComponent],
@@ -106,6 +109,7 @@ describe('AppComponent', () => {
     app.onConsentChange(false);
     expect(analyticsService.updateConsent).toHaveBeenCalledTimes(3);
     expect(analyticsService.updateConsent).toHaveBeenCalledWith(false);
+    expect(analyticsService.initialize).toHaveBeenCalledTimes(1);
     app.onConsentChange(true);
     expect(analyticsService.initialize).toHaveBeenCalledTimes(2);
     expect(analyticsService.updateConsent).toHaveBeenCalledTimes(4);

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -72,14 +72,14 @@ export class AppComponent implements OnInit {
       return;
     }
 
+    this.analyticsService.updateConsent(consentGranted);
+
     if (consentGranted) {
-      this.analyticsService.updateConsent(true);
       if (!this.analyticsConsentGranted) {
         this.analyticsService.initialize();
-        this.analyticsConsentGranted = true;
       }
+      this.analyticsConsentGranted = true;
     } else {
-      this.analyticsService.updateConsent(false);
       this.analyticsConsentGranted = false;
     }
   }

--- a/src/app/services/analytics.service.spec.ts
+++ b/src/app/services/analytics.service.spec.ts
@@ -84,22 +84,23 @@ describe('AnalyticsService', () => {
     expect(script).not.toBeNull();
   });
 
-  it('should initialise gtag and send consent updates even before loading the script', () => {
+  it('should initialise dataLayer immediately and send default consent before updates', () => {
     const analyticsService = getService();
     const doc = getDocument();
     const win = doc.defaultView as Window & { dataLayer?: unknown[]; gtag?: jasmine.Spy } | null;
 
+    expect(Array.isArray(win?.dataLayer)).toBeTrue();
+
     analyticsService.updateConsent(false);
 
     expect(win?.dataLayer).toBeTruthy();
-    expect(Array.isArray(win?.dataLayer)).toBeTrue();
     expect(typeof win?.gtag).toBe('function');
 
     const dataLayerEntries = (win?.dataLayer as IArguments[]) ?? [];
     expect(dataLayerEntries.length).toBe(2);
     expect(Array.from(dataLayerEntries[0])).toEqual([
       'consent',
-      'update',
+      'default',
       { analytics_storage: 'denied', ad_storage: 'denied' },
     ]);
     expect(Array.from(dataLayerEntries[1])).toEqual([

--- a/src/app/services/analytics.service.ts
+++ b/src/app/services/analytics.service.ts
@@ -20,7 +20,11 @@ export class AnalyticsService {
     @Inject(APP_ENVIRONMENT) private readonly environment: EnvironmentConfig,
     @Inject(DOCUMENT) private readonly documentRef: Document,
     @Inject(PLATFORM_ID) private readonly platformId: Object,
-  ) { }
+  ) {
+    if (isPlatformBrowser(this.platformId)) {
+      this.initializeDataLayer();
+    }
+  }
 
   initialize(): void {
     if (!this.shouldBootstrapAnalytics()) {
@@ -52,7 +56,7 @@ export class AnalyticsService {
     this.ensureAnalyticsStubs(win);
 
     if (!this.isConsentDefaultSent) {
-      win.gtag('consent', 'update', { analytics_storage: 'denied', ad_storage: 'denied' });
+      win.gtag('consent', 'default', { analytics_storage: 'denied', ad_storage: 'denied' });
       this.isConsentDefaultSent = true;
     }
 
@@ -132,5 +136,14 @@ export class AnalyticsService {
       // eslint-disable-next-line prefer-rest-params
       (win.dataLayer as unknown[]).push(arguments);
     };
+  }
+
+  private initializeDataLayer(): void {
+    const win = this.documentRef.defaultView as AnalyticsWindow | null;
+    if (!win) {
+      return;
+    }
+
+    win.dataLayer = win.dataLayer || [];
   }
 }


### PR DESCRIPTION
## Summary
- initialize the analytics dataLayer on service creation so consent events can queue before the gtag script loads
- emit both the denied default and subsequent consent updates and guard initialization until consent is granted
- extend analytics and app component unit tests to cover the consent flow and script bootstrap requirements

## Testing
- npm run test:headless *(fails: shell does not support command substitution)*
- npm test -- --watch=false --browsers=ChromeHeadlessPuppeteer *(fails: ng command unavailable without local dependencies)*
- npm ci *(fails: npm registry returned 403 when installing @angular/compiler-cli)*

------
https://chatgpt.com/codex/tasks/task_e_68fbaead46ec832bb15fd74e6899073f